### PR TITLE
Past Sessions: filter dropdown, type ordering, data corrections

### DIFF
--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -14,7 +14,11 @@
             "speaker": "Arjun Panickssery"
           },
           {
-            "title": "manifold.love meetup #0",
+            "title": "Figgie",
+            "speaker": "Arjun Panickssery"
+          },
+          {
+            "title": "Manifold.love Meetup #0",
             "speaker": "Sinclair Chen"
           },
           {
@@ -22,7 +26,7 @@
             "speaker": "Robin Hanson"
           },
           {
-            "title": "Manifold Founder & Theo Jaffee: Fireside Chat",
+            "title": "Manifold Founder SG & Theo Jaffee: Fireside Chat",
             "speaker": "Stephen Grugett"
           }
         ]
@@ -57,6 +61,10 @@
           {
             "title": "Poker Satellite #1",
             "speaker": "David Chee"
+          },
+          {
+            "title": "Ricki and Dave's Kabbalat Shabbat",
+            "speaker": "Dave Kasten"
           }
         ]
       },
@@ -80,6 +88,10 @@
             "speaker": "Saul Munn"
           },
           {
+            "title": "Speedfriending Overflow",
+            "speaker": "Saul Munn"
+          },
+          {
             "title": "Night Market & Career Fair",
             "speaker": "David Chee"
           },
@@ -96,7 +108,7 @@
             "speaker": "Rachel Wallis"
           },
           {
-            "title": "Stratospheric Aerosol Injection Balloon Launch",
+            "title": "Make Sunset Stratospheric Aerosol Injection Balloon Launch",
             "speaker": "Andrew Song"
           },
           {
@@ -142,7 +154,7 @@
             "speaker": "Sam Penrose"
           },
           {
-            "title": "Weird Findings in Exercise Science",
+            "title": "Weird Findings in the Last 10 Years of Exercise Science",
             "speaker": "Andrew Rettek"
           },
           {
@@ -164,6 +176,34 @@
           {
             "title": "Our Broken High-Skilled Immigration System",
             "speaker": "Jasmine Ren"
+          },
+          {
+            "title": "Speedfriending #2",
+            "speaker": "Saul Munn"
+          },
+          {
+            "title": "Experimental Meditation Experiments",
+            "speaker": "Raj Thimmiah"
+          },
+          {
+            "title": "Manifold Users Meetup (Day 2)",
+            "speaker": "Dylan (@Ziddletwix)"
+          },
+          {
+            "title": "Poker Satellite #2",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "Talk to a Rationalist Leftist",
+            "speaker": "David Youssef"
+          },
+          {
+            "title": "Memory Systems / Anki / SRS Meetup",
+            "speaker": "Saul Munn"
+          },
+          {
+            "title": "Manifestation",
+            "speaker": "Sinclair Chen"
           }
         ]
       },
@@ -213,6 +253,30 @@
           {
             "title": "Nate Silver & Chris Best Discussion",
             "speaker": "Nate Silver"
+          },
+          {
+            "title": "ThermoRex Fanclub",
+            "speaker": "Christian Larsen"
+          },
+          {
+            "title": "Poker Satellite #3",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "How I've Had More Sex (Talk + Ama)",
+            "speaker": "Nathan Young"
+          },
+          {
+            "title": "Manifold Lore Jeopardy!",
+            "speaker": "Jacob Cohen"
+          },
+          {
+            "title": "Pitch Competition Judges Huddle",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "NHK Prediction Markets and Financial Research",
+            "speaker": ""
           }
         ]
       },
@@ -224,11 +288,11 @@
             "speaker": "Crémieux"
           },
           {
-            "title": "Election Betting Debates of 2024: A Retrospective",
+            "title": "Decision Betting Debates of 2024: a Retrospective",
             "speaker": "Brennan Robbins"
           },
           {
-            "title": "patio11 + kuiper: Emergent Gameplay & Narrative",
+            "title": "Patio11 + Kuiper: Emergent Gameplay & Narrative",
             "speaker": "Justin Kuiper"
           },
           {
@@ -236,11 +300,11 @@
             "speaker": "Vivienne Bellerose"
           },
           {
-            "title": "How To Change Your Mind (with Replacement Therapies)",
+            "title": "How to Change Your Mind (with Replacement Therapies)",
             "speaker": "Matt Buckley"
           },
           {
-            "title": "Doom Debates: Liron vs. Everyone",
+            "title": "Doom Debates: Liron Vs. Everyone",
             "speaker": "Liron Shapira"
           },
           {
@@ -260,7 +324,7 @@
             "speaker": "Ric Best"
           },
           {
-            "title": "Richard Hanania: A Decade of Trump Forecasting",
+            "title": "Richard Hanania: a Decade of Trump Forecasting",
             "speaker": "Richard Hanania"
           },
           {
@@ -269,7 +333,7 @@
           },
           {
             "title": "Fine-Tuning, the Multiverse & Anthropic Bias",
-            "speaker": "Rom Gruman"
+            "speaker": "Rom (Rami) Gruman"
           },
           {
             "title": "David Shor: Data Science & Politics",
@@ -286,6 +350,58 @@
           {
             "title": "AI Welfare",
             "speaker": "Joe Carlsmith"
+          },
+          {
+            "title": "The Intersection of NTRPs and Prediction Markets",
+            "speaker": "Edward Lee"
+          },
+          {
+            "title": "Read Some Poetry You Like",
+            "speaker": "Jennifer Chen"
+          },
+          {
+            "title": "Pitch Competition Setup / Rapid FIRE Tips",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "Question Overflow",
+            "speaker": "Nathan Young"
+          },
+          {
+            "title": "Theory of Podcast (in Gardens)",
+            "speaker": "Sammy"
+          },
+          {
+            "title": "Arts & Crafts: Build a Marble Race Track",
+            "speaker": "Ian Philips"
+          },
+          {
+            "title": "Poker Satellite #4",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "Rare & Exotic-Ish Drama Games from Australia",
+            "speaker": ""
+          },
+          {
+            "title": "Atlas Meetup",
+            "speaker": "David Lieman"
+          },
+          {
+            "title": "Quizbowl / Trivia",
+            "speaker": "Stevie Miller"
+          },
+          {
+            "title": "Banterbrush: Chill, Chat and Make Art",
+            "speaker": "Skyler"
+          },
+          {
+            "title": "Niacin Hot Seat",
+            "speaker": "Matthew Leo"
+          },
+          {
+            "title": "Awkwardmaxxing for the Socially Anxious",
+            "speaker": ""
           }
         ]
       },
@@ -329,7 +445,7 @@
             "speaker": "Scott Alexander"
           },
           {
-            "title": "Nash Pit: A Prediction Market Game Show",
+            "title": "Nash Pit: a Prediction Market Game Show",
             "speaker": "Roque Dietrich"
           },
           {
@@ -343,6 +459,26 @@
           {
             "title": "Dance Party",
             "speaker": "Aella"
+          },
+          {
+            "title": "Acro",
+            "speaker": "Fredrik Ekholm"
+          },
+          {
+            "title": "LGBT Meetup",
+            "speaker": "Dony Christie"
+          },
+          {
+            "title": "Aella Meetup",
+            "speaker": "Aella"
+          },
+          {
+            "title": "Quaker Meetup",
+            "speaker": ""
+          },
+          {
+            "title": "Arm Wrestling Tournament",
+            "speaker": "Henri Lemoine"
           }
         ]
       }
@@ -363,7 +499,7 @@
             "speaker": "Clark"
           },
           {
-            "title": "Kalshi Sports: The Why & How",
+            "title": "Kalshi Sports: the Why & How",
             "speaker": "Noah Sternig"
           },
           {
@@ -387,7 +523,7 @@
             "speaker": "Patrick McKenzie"
           },
           {
-            "title": "Futuur & predict.pm: Order Books, MCPs, Aggregators",
+            "title": "Futuur & Predict.pm: Order Books, MCPs, Aggregators",
             "speaker": "Tom Bennett"
           },
           {
@@ -399,12 +535,28 @@
             "speaker": "Pablo Peniche"
           },
           {
-            "title": "Droning On (Ukraine Drone Discussion)",
+            "title": "Droning on (Ukraine Drone Discussion)",
             "speaker": "Nathan Young"
           },
           {
             "title": "Decision Markets Are Broken — How Do We Fix Them?",
             "speaker": "Drake Thomas"
+          },
+          {
+            "title": "Experimental Meditation Experiments",
+            "speaker": "Raj Thimmiah"
+          },
+          {
+            "title": "Catholic Mass at Newman Parish",
+            "speaker": ""
+          },
+          {
+            "title": "Discussing Anthropic's Impact",
+            "speaker": "Joe Rogero"
+          },
+          {
+            "title": "Poker Satellite #6",
+            "speaker": "David Chee"
           }
         ]
       },
@@ -416,7 +568,7 @@
             "speaker": "David Chee"
           },
           {
-            "title": "Wave's Culture: A Debrief",
+            "title": "Wave's Culture: a Debrief",
             "speaker": "Lincoln Quirk"
           },
           {
@@ -424,7 +576,7 @@
             "speaker": "Jeremiah Johnson"
           },
           {
-            "title": "What We've Learned Doing Futarchy For a Year",
+            "title": "What We've Learned Doing Futarchy for a Year",
             "speaker": "Proph3t"
           },
           {
@@ -444,7 +596,7 @@
             "speaker": "Michael Lachanski"
           },
           {
-            "title": "GLP-1 Discussion Group",
+            "title": "Glp-1 Discussion Group",
             "speaker": "Andrew Rettek"
           },
           {
@@ -458,6 +610,10 @@
           {
             "title": "American Manufacturing War Room",
             "speaker": "Matt Parlmer"
+          },
+          {
+            "title": "The Furry Slayer",
+            "speaker": "Tracing Woodgrains"
           }
         ]
       },
@@ -511,6 +667,111 @@
           {
             "title": "An Asian Perspective of Prediction Markets",
             "speaker": "Nancy Yi"
+          },
+          {
+            "title": "London Meetup",
+            "speaker": "Sam"
+          },
+          {
+            "title": "Men's Fashion Advice",
+            "speaker": "Rachel Weinberg"
+          },
+          {
+            "title": "Overcoming Sexual Shame",
+            "speaker": "Jehan Azad"
+          },
+          {
+            "title": "Simple Improv Games",
+            "speaker": "Simon Baars"
+          },
+          {
+            "title": "Women Who Wouldn't Be Caught Dead at a 'Women In...' Event",
+            "speaker": "Jennifer Chen"
+          },
+          {
+            "title": "Kalshi's Great Bean Content Reveal",
+            "speaker": "Noah Sternig"
+          },
+          {
+            "title": "A History of Predictive Processing from Democritus",
+            "speaker": "Emmett Shear"
+          },
+          {
+            "title": "Prediction, Personalization, Participation: the Bayes Bandit",
+            "speaker": "Jacky Chu"
+          },
+          {
+            "title": "The Case for Interactionist Dualism",
+            "speaker": "Vivienne Bellerose"
+          },
+          {
+            "title": "Poetry Art Jam Renga Party",
+            "speaker": "Malcolm Jackson"
+          },
+          {
+            "title": "Similarities Between Selling to Nation States and on Facebook Marketplace",
+            "speaker": "Jimmy Hsu"
+          },
+          {
+            "title": "AI Will Not Be Conscious (Blindsight Hypothesis)",
+            "speaker": "Brett aka Tumbles"
+          },
+          {
+            "title": "Prediction Market Parlays",
+            "speaker": "Benjamin Scheinberg"
+          },
+          {
+            "title": "Poker Satellite #7",
+            "speaker": "David Chee"
+          }
+        ]
+      },
+      {
+        "slot": "Evening",
+        "sessions": [
+          {
+            "title": "Closing Ceremony",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "Dinner (Starts 5:30)",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "Big Manifold Awards Ceremony",
+            "speaker": "Ian Philips"
+          },
+          {
+            "title": "Reserved",
+            "speaker": "John Bennett"
+          },
+          {
+            "title": "Tech, Policy, and the Future of Private Equity",
+            "speaker": "Alex Aridgides"
+          },
+          {
+            "title": "Good Cities",
+            "speaker": "Theo Jaffee"
+          },
+          {
+            "title": "Robot Meetup",
+            "speaker": "Tessa Barton"
+          },
+          {
+            "title": "Fun Etymology",
+            "speaker": "Alok Singh"
+          },
+          {
+            "title": "Poker Final Table",
+            "speaker": "David Chee"
+          },
+          {
+            "title": "Rock Paper Scissors Poker",
+            "speaker": "chris (strutheo)"
+          },
+          {
+            "title": "Light Night Hangouts / Dance Party / Other Closing Socials",
+            "speaker": "David Chee"
           }
         ]
       }

--- a/public/pastsessions/events.json
+++ b/public/pastsessions/events.json
@@ -16,7 +16,7 @@
       },
       {
         "color": "orange",
-        "title": "Retrofund more than just crypto",
+        "title": "Retrofund More Than Just Crypto",
         "hosts": "Evan Miyazono",
         "rsvp": 22
       },
@@ -40,25 +40,25 @@
       },
       {
         "color": "yellow",
-        "title": "What do AI models think of news and prediction markets?",
+        "title": "What Do AI Models Think of News and Prediction Markets?",
         "hosts": "Nikolai Yakovenko",
         "rsvp": 43
       },
       {
         "color": "yellow",
-        "title": "Increasing access to the Jhanas",
+        "title": "Increasing Access to the Jhanas",
         "hosts": "Alex Gruver",
         "rsvp": 37
       },
       {
         "color": "yellow",
-        "title": "Why prediction markets need financial derivatives",
+        "title": "Why Prediction Markets Need Financial Derivatives",
         "hosts": "Joseph Toles",
         "rsvp": 29
       },
       {
         "color": "yellow",
-        "title": "CMV: prediction market theory is weak",
+        "title": "CMV: Prediction Market Theory Is Weak",
         "hosts": "Phil Hazelden",
         "rsvp": 6
       },
@@ -70,8 +70,8 @@
       },
       {
         "color": "lime",
-        "title": "Anthropics discussion (the kind of reasoning, not the company)",
-        "hosts": "Matthew Adelstein",
+        "title": "Anthropics Discussion (the Kind of Reasoning, Not the Company)",
+        "hosts": "Bentham's Bulldog",
         "rsvp": 30
       },
       {
@@ -82,19 +82,19 @@
       },
       {
         "color": "lime",
-        "title": "Forecasting Complex Scenarios with Scorable Functions, using Squiggle",
+        "title": "Forecasting Complex Scenarios with Scorable Functions, Using Squiggle",
         "hosts": "Ozzie Gooen",
         "rsvp": 30
       },
       {
         "color": "lime",
-        "title": "Crafting great AI strategy forecasting questions, with scorable functions",
+        "title": "Crafting Great AI Strategy Forecasting Questions, with Scorable Functions",
         "hosts": "Ozzie Gooen",
         "rsvp": 3
       },
       {
         "color": "lime",
-        "title": "Theo Jaffee interviews Stephen Grugett",
+        "title": "Theo Jaffee Interviews Stephen Grugett",
         "hosts": "Stephen Grugett, Theodore Jaffee",
         "rsvp": 34
       },
@@ -106,25 +106,25 @@
       },
       {
         "color": "lime",
-        "title": "Movie night",
+        "title": "Movie Night",
         "hosts": "Alok Singh",
         "rsvp": 0
       },
       {
         "color": "teal",
-        "title": "Ukraine war: Forecast and bet",
+        "title": "Ukraine War: Forecast and Bet",
         "hosts": "Nathan Young",
         "rsvp": 20
       },
       {
         "color": "cyan",
-        "title": "Actually Good theories of psychological growth",
+        "title": "Actually Good Theories of Psychological Growth",
         "hosts": "Chris Lakin",
         "rsvp": 45
       },
       {
         "color": "cyan",
-        "title": "Informal Shabbat Services led by Ricki Heicklen and Dave Kasten",
+        "title": "Informal Shabbat Services Led by Ricki Heicklen and Dave Kasten",
         "hosts": "Ricki Heicklen, Dave Kasten",
         "rsvp": 17
       }
@@ -160,7 +160,7 @@
       },
       {
         "color": "rose",
-        "title": "Why so much disagreement about AI risk?",
+        "title": "Why So Much Disagreement About AI Risk?",
         "hosts": "Josh Rosenberg, Scott Alexander, Misha Glouberman",
         "rsvp": 131
       },
@@ -172,7 +172,7 @@
       },
       {
         "color": "rose",
-        "title": "What will March 2020 for AI look like?",
+        "title": "What Will March 2020 for AI Look Like?",
         "hosts": "Dwarkesh Patel",
         "rsvp": 110
       },
@@ -184,19 +184,19 @@
       },
       {
         "color": "rose",
-        "title": "Q&A with Kalshi co-founder & CTO, Luana Lopez",
+        "title": "Q&A with Kalshi Co-Founder & CTO, Luana Lopez",
         "hosts": "Luana Lopes Lara, Noah Sternig",
         "rsvp": 32
       },
       {
         "color": "orange",
-        "title": "How demographic collapse will affect geopolitics, culture, economics, infrastructure, and more",
+        "title": "How Demographic Collapse Will Affect Geopolitics, Culture, Economics, Infrastructure, and More",
         "hosts": "Malcolm Collins, Simone Collins",
         "rsvp": 57
       },
       {
         "color": "orange",
-        "title": "Metaculus: $120k AI Benchmarking Tournament Announcement & Build-a-Bot Workshop",
+        "title": "Metaculus: $120K AI Benchmarking Tournament Announcement & Build-A-Bot Workshop",
         "hosts": "Deger Turan, Tom Liptay",
         "rsvp": 48
       },
@@ -220,19 +220,19 @@
       },
       {
         "color": "orange",
-        "title": "Forecasting the biological century",
+        "title": "Forecasting the Biological Century",
         "hosts": "Razib Khan",
         "rsvp": 75
       },
       {
         "color": "orange",
-        "title": "Forecasting has not taken off. What should we do about it?",
+        "title": "Forecasting Has Not Taken Off. What Should We Do About It?",
         "hosts": "Javier Prieto",
         "rsvp": 39
       },
       {
         "color": "orange",
-        "title": "FutureSearch: A new question answering AI",
+        "title": "FutureSearch: a New Question Answering AI",
         "hosts": "Dan Schwarz",
         "rsvp": 53
       },
@@ -244,7 +244,7 @@
       },
       {
         "color": "orange",
-        "title": "Ring Signatures: A tool for whistleblowing",
+        "title": "Ring Signatures: a Tool for Whistleblowing",
         "hosts": "Kurt  Brown",
         "rsvp": 10
       },
@@ -262,7 +262,7 @@
       },
       {
         "color": "yellow",
-        "title": "Design Your Own Compute Market (SF Compute)",
+        "title": "Design Your Own Compute Market (Sf Compute)",
         "hosts": "Alex Gajewski",
         "rsvp": 33
       },
@@ -274,7 +274,7 @@
       },
       {
         "color": "yellow",
-        "title": "How to make superbabies",
+        "title": "How to Make Superbabies",
         "hosts": "Gene Smith",
         "rsvp": 82
       },
@@ -298,13 +298,13 @@
       },
       {
         "color": "yellow",
-        "title": "YouTube: free eyeballs are free $100 bills",
+        "title": "YouTube: Free Eyeballs Are Free $100 Bills",
         "hosts": "Justin Kuiper",
         "rsvp": 50
       },
       {
         "color": "yellow",
-        "title": "Neopets: The feudal lords reigning over a dying world",
+        "title": "Neopets: the Feudal Lords Reigning Over a Dying World",
         "hosts": "Tracing Woodgrains",
         "rsvp": 75
       },
@@ -316,13 +316,13 @@
       },
       {
         "color": "lime",
-        "title": "Meme Markets: Embracing the primordial chaos",
+        "title": "Meme Markets: Embracing the Primordial Chaos",
         "hosts": "Kelton Madden, Michael Elias",
         "rsvp": 17
       },
       {
         "color": "lime",
-        "title": "The economics of envy",
+        "title": "The Economics of Envy",
         "hosts": "Brian Chau",
         "rsvp": 30
       },
@@ -358,7 +358,7 @@
       },
       {
         "color": "lime",
-        "title": "Theo Jaffee interviews Austin Chen",
+        "title": "Theo Jaffee Interviews Austin Chen",
         "hosts": "Theodore Jaffee, Austin Chen",
         "rsvp": 16
       },
@@ -388,7 +388,7 @@
       },
       {
         "color": "green",
-        "title": "Events should be good, not bad",
+        "title": "Events Should Be Good, Not Bad",
         "hosts": "Austin Chen, Misha Glouberman",
         "rsvp": 48
       },
@@ -412,13 +412,13 @@
       },
       {
         "color": "green",
-        "title": "Repolarize American Politics: How to make the two-party system irrelevant",
+        "title": "Repolarize American Politics: How to Make the Two-Party System Irrelevant",
         "hosts": "Barak Gila",
         "rsvp": 20
       },
       {
         "color": "green",
-        "title": "Build the future of universities with me",
+        "title": "Build the Future of Universities with Me",
         "hosts": "Madhu Sriram",
         "rsvp": 13
       },
@@ -442,31 +442,31 @@
       },
       {
         "color": "teal",
-        "title": "Why are you stuck on your novel?",
+        "title": "Why Are You Stuck on Your Novel?",
         "hosts": "Sy Etirabys",
         "rsvp": 3
       },
       {
         "color": "cyan",
-        "title": "Meetup: Manifold whales & degens",
+        "title": "Meetup: Manifold Whales & Degens",
         "hosts": "No hosts",
         "rsvp": 21
       },
       {
         "color": "cyan",
-        "title": "Psychological growth 2",
+        "title": "Psychological Growth 2",
         "hosts": "Chris Lakin",
         "rsvp": 22
       },
       {
         "color": "cyan",
-        "title": "Deliberate Grieving (and/or Ruthlessness and/or \"Whoops!\")",
+        "title": "Deliberate Grieving (And/Or Ruthlessness And/Or \"Whoops!\")",
         "hosts": "Raymond Arnold",
         "rsvp": 3
       },
       {
         "color": "blue",
-        "title": "The Operant Conditioning Game\n",
+        "title": "The Operant Conditioning Game",
         "hosts": "Brendan Hurst",
         "rsvp": 1
       },
@@ -502,7 +502,7 @@
       },
       {
         "color": "blue",
-        "title": "Blood on the Clocktower ",
+        "title": "Blood on the Clocktower",
         "hosts": "Brendan Hurst",
         "rsvp": 1
       },
@@ -520,7 +520,7 @@
       },
       {
         "color": "blue",
-        "title": "possible Blood on the Clocktower?",
+        "title": "Possible Blood on the Clocktower?",
         "hosts": "Brendan Hurst",
         "rsvp": 0
       }
@@ -556,7 +556,7 @@
       },
       {
         "color": "rose",
-        "title": "Behind the Numbers: Eliciting Rationales to Improve Decision-making",
+        "title": "Behind the Numbers: Eliciting Rationales to Improve Decision-Making",
         "hosts": "Cate Hall, Dan Schwarz, Josh Rosenberg, Deger Turan",
         "rsvp": 61
       },
@@ -580,7 +580,7 @@
       },
       {
         "color": "orange",
-        "title": "Press X to doubt: journalism edition",
+        "title": "Press X to Doubt: Journalism Edition",
         "hosts": "Patrick McKenzie",
         "rsvp": 97
       },
@@ -592,13 +592,13 @@
       },
       {
         "color": "orange",
-        "title": "Manifund: Impact certs & beyond",
+        "title": "Manifund: Impact Certs & Beyond",
         "hosts": "Austin Chen, Rachel Weinberg",
         "rsvp": 31
       },
       {
         "color": "orange",
-        "title": "Technology trees for ambitious futures ",
+        "title": "Technology Trees for Ambitious Futures",
         "hosts": "Allison Duettmann",
         "rsvp": 73
       },
@@ -640,7 +640,7 @@
       },
       {
         "color": "yellow",
-        "title": "AI threat modeling needs forecasters: closing the gap between evals and reality",
+        "title": "AI Threat Modeling Needs Forecasters: Closing the Gap Between Evals and Reality",
         "hosts": "Joshua Clymer",
         "rsvp": 35
       },
@@ -652,7 +652,7 @@
       },
       {
         "color": "lime",
-        "title": "Beyond Red and Blue: How would American politics look with a different system?",
+        "title": "Beyond Red and Blue: How Would American Politics Look with a Different System?",
         "hosts": "Karthik Ayyalasomayajula",
         "rsvp": 7
       },
@@ -670,31 +670,31 @@
       },
       {
         "color": "lime",
-        "title": "X-risk and your feelings",
+        "title": "X-Risk and Your Feelings",
         "hosts": "Misha Glouberman, Gretta Duleba",
         "rsvp": 51
       },
       {
         "color": "lime",
-        "title": "What is Aristotle's Metaphysics about?",
+        "title": "What Is Aristotle's Metaphysics About?",
         "hosts": "Arnold Brooks",
         "rsvp": 31
       },
       {
         "color": "lime",
-        "title": "Salesforce, Memex, and the self-structuring Exacortex: Using language models to automate the creation of ontologies and reshape organizations",
+        "title": "Salesforce, Memex, and the Self-Structuring Exacortex: Using Language Models to Automate the Creation of Ontologies and Reshape Organizations",
         "hosts": "Panda Smith",
         "rsvp": 27
       },
       {
         "color": "green",
-        "title": "Top Manifold traders discuss trading in real-world markets.",
+        "title": "Top Manifold Traders Discuss Trading in Real-World Markets.",
         "hosts": "Michael Wheatley",
         "rsvp": 16
       },
       {
         "color": "green",
-        "title": "Doom near-miss liability: my favourite AI risk policy",
+        "title": "Doom Near-Miss Liability: My Favourite AI Risk Policy",
         "hosts": "Daniel Filan",
         "rsvp": 33
       },
@@ -718,7 +718,7 @@
       },
       {
         "color": "green",
-        "title": "Metaculus Build-a-Bot Office Hours",
+        "title": "Metaculus Build-A-Bot Office Hours",
         "hosts": "Deger Turan, Tom Liptay",
         "rsvp": 18
       },
@@ -730,7 +730,7 @@
       },
       {
         "color": "green",
-        "title": "Fiction writing: good prose vs bad prose, humans vs LLMs",
+        "title": "Fiction Writing: Good Prose vs Bad Prose, Humans vs LLMs",
         "hosts": "Justin Kuiper",
         "rsvp": 22
       },
@@ -742,13 +742,13 @@
       },
       {
         "color": "teal",
-        "title": "A web3+AI prediction market?",
+        "title": "A Web3+AI Prediction Market?",
         "hosts": "Rein Wu",
         "rsvp": 2
       },
       {
         "color": "teal",
-        "title": "Portfolio construction 2",
+        "title": "Portfolio Construction 2",
         "hosts": "Pepe Swer",
         "rsvp": 4
       },
@@ -760,7 +760,7 @@
       },
       {
         "color": "cyan",
-        "title": "Reforming Academia Via Reputation Futures",
+        "title": "Reforming Academia via Reputation Futures",
         "hosts": "Robin Hanson",
         "rsvp": 32
       },
@@ -772,7 +772,7 @@
       },
       {
         "color": "cyan",
-        "title": "Barbell Coaching [VENUE: AT THE GYM]",
+        "title": "Barbell Coaching [Venue: at the Gym]",
         "hosts": "Tzu Kit Chan",
         "rsvp": 8
       },
@@ -814,7 +814,7 @@
       },
       {
         "color": "blue",
-        "title": "Blood on the Clocktower ",
+        "title": "Blood on the Clocktower",
         "hosts": "Brendan Hurst",
         "rsvp": 6
       }

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -73,6 +73,39 @@
 
   .year-meta { font-size: 14px; color: var(--muted); margin-bottom: 22px; }
 
+  .filter-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 22px;
+    flex-wrap: wrap;
+  }
+  .filter-row label {
+    font-family: var(--font-cinzel);
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 600;
+  }
+  .filter-row select {
+    font-family: var(--font-cinzel);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--ink);
+    background: var(--panel);
+    border: 1px solid var(--rule);
+    border-radius: 999px;
+    padding: 8px 32px 8px 16px;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path fill='none' stroke='%236b5f4f' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' d='M1 1l5 5 5-5'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+  }
+  .filter-row select:hover { border-color: var(--ink); }
+
   .day-section {
     border-top: 1px solid var(--rule);
     padding-top: 22px;
@@ -195,6 +228,14 @@
   </nav>
 
   <div id="year-meta" class="year-meta"></div>
+
+  <div class="filter-row">
+    <label for="cat-filter">Filter by type</label>
+    <select id="cat-filter">
+      <option value="all">All types</option>
+    </select>
+  </div>
+
   <main id="schedule"></main>
 
   <footer class="site">
@@ -382,6 +423,7 @@ async function loadYear(year) {
   document.getElementById('footer-text').textContent = `Manifest ${year}`;
 
   // Render schedule
+  const catOrder = Object.fromEntries(CATEGORIES.map((c, i) => [c.key, i]));
   const main = document.getElementById('schedule');
   main.innerHTML = '';
   for (const d of data) {
@@ -393,8 +435,13 @@ async function loadYear(year) {
     const grid = document.createElement('div');
     grid.className = 'session-grid';
 
-    for (const s of visible) {
-      const item = createSessionCard(s);
+    const items = visible.map(s => createSessionCard(s));
+    items.sort((a, b) => {
+      const ai = catOrder[a.cat] ?? 99;
+      const bi = catOrder[b.cat] ?? 99;
+      return ai - bi;
+    });
+    for (const item of items) {
       grid.appendChild(item.card);
     }
     sec.appendChild(grid);
@@ -404,13 +451,46 @@ async function loadYear(year) {
 
 document.querySelectorAll('nav.years button').forEach(btn => {
   btn.addEventListener('click', () => {
-    loadYear(btn.dataset.year);
+    loadYear(btn.dataset.year).then(() => { refreshFilterOptions(); applyFilter(); });
     history.replaceState(null, '', '#year-' + btn.dataset.year);
   });
 });
 
+// Filter dropdown
+const filterSelect = document.getElementById('cat-filter');
+
+function refreshFilterOptions() {
+  const present = new Set();
+  document.querySelectorAll('#schedule .session').forEach(c => present.add(c.dataset.cat));
+  const previous = filterSelect.value || 'all';
+  filterSelect.innerHTML = '<option value="all">All types</option>';
+  for (const cat of CATEGORIES) {
+    if (!present.has(cat.key)) continue;
+    const opt = document.createElement('option');
+    opt.value = cat.key;
+    opt.textContent = cat.label;
+    filterSelect.appendChild(opt);
+  }
+  filterSelect.value = present.has(previous) || previous === 'all' ? previous : 'all';
+}
+
+function applyFilter() {
+  const cat = filterSelect.value;
+  document.querySelectorAll('.day-section').forEach(section => {
+    let visibleCount = 0;
+    section.querySelectorAll('.session').forEach(card => {
+      const match = cat === 'all' || card.dataset.cat === cat;
+      card.style.display = match ? '' : 'none';
+      if (match) visibleCount++;
+    });
+    section.style.display = visibleCount === 0 ? 'none' : '';
+  });
+}
+
+filterSelect.addEventListener('change', applyFilter);
+
 const initialYear = (location.hash.match(/year-(2024|2025)/) || [,'2025'])[1];
-loadYear(initialYear);
+loadYear(initialYear).then(() => { refreshFilterOptions(); applyFilter(); });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add a "Filter by type" dropdown above the schedule. It only lists categories actually present in the selected year, and re-applies when switching year tabs (so empty days hide).
- Sort sessions within each day by category type so cards of the same type cluster together in the 3-column grid.
- Many 2025 schedule data corrections from cross-referencing the original schedule:
  - Add ~20 missing sessions across all three days
  - Fix title misreads (ThermoRex Fanclub, Decision Betting Debates of 2024, A History of Predictive Processing from Democritus, The Bayes Bandit, Build a Marble Race Track, etc.)
  - Fill in missing speakers (Raj Thimmiah, Christian Larsen, Rachel Weinberg, Simon Baars, Vivienne Bellerose, Tracing Woodgrains, Joe Rogero, Sam, etc.)
- Title-case every session title in both events.json (2024) and events-2025.json (2025).
- Replace Matthew Adelstein with Bentham's Bulldog in 2024 data.

## Test plan
- [ ] Load /pastsessions/ and switch between Manifest 2025 / Manifest 2024 — confirm dropdown reflects available categories per year
- [ ] Pick a category in the dropdown — only matching cards render and any day with no matches collapses
- [ ] Within each day, cards of the same category appear adjacent in the column grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
