### PR TITLE
Add 2023 schedule to /pastsessions

### DIFF
--- a/public/pastsessions/events-2023.json
+++ b/public/pastsessions/events-2023.json
@@ -1,0 +1,345 @@
+[
+  {
+    "day": "Friday, September 22",
+    "events": [
+      {
+        "title": "Hang Out and Laugh: Monikers",
+        "hosts": "Matt C. Wilson"
+      },
+      {
+        "title": "Team Forecasting",
+        "hosts": "Michael Wheatley"
+      },
+      {
+        "title": "Prediction Markets Evangelism",
+        "hosts": "James Grugett, Stephen Grugett"
+      },
+      {
+        "title": "Poker: Satellite Table #1",
+        "hosts": "David Chee"
+      },
+      {
+        "title": "Optic Panel",
+        "hosts": "Tom Shlomi, Saul Munn"
+      },
+      {
+        "title": "Speedfriending Event #1",
+        "hosts": ""
+      },
+      {
+        "title": "Prediction Markets Applied to Finance",
+        "hosts": "Louis Clouatre-Latraverse, Stephen Grugett"
+      },
+      {
+        "title": "Improving AI Benchmarks",
+        "hosts": "Isabel Juniewicz, Stephen Grugett, Nathan Young"
+      },
+      {
+        "title": "Learn Poker",
+        "hosts": "Max Chiswick"
+      },
+      {
+        "title": "Prediction Markets in Journalism",
+        "hosts": "Dylan Matthews, Nathan Young"
+      },
+      {
+        "title": "Karaoke + Live Betting",
+        "hosts": "Ian Philips"
+      },
+      {
+        "title": "MTG Sealed Tournament (Wilds of Eldraine)",
+        "hosts": "Austin Chen"
+      },
+      {
+        "title": "Predicting War Markets",
+        "hosts": "Douglas Campbell, Abhishek Kylasa, Nathan Young"
+      },
+      {
+        "title": "Political Betting Regulation: Pathways to Liberalization",
+        "hosts": "Pratik Chougule, Douglas Campbell"
+      },
+      {
+        "title": "Rise into Rave Heaven",
+        "hosts": "Ian Philips"
+      }
+    ]
+  },
+  {
+    "day": "Saturday, September 23",
+    "events": [
+      {
+        "title": "Build a Trading Bot Workshop",
+        "hosts": "Stephen Grugett"
+      },
+      {
+        "title": "How to Take a Perfect Dating Photo",
+        "hosts": "Nikita Sokolsky"
+      },
+      {
+        "title": "Verifiable Computing and Homomorphically Encrypted Data Sets — Oh My!",
+        "hosts": "James McGirk"
+      },
+      {
+        "title": "LK-99 Q&A",
+        "hosts": "Seo Sanghyeon"
+      },
+      {
+        "title": "Cornhole RPG",
+        "hosts": "Adrian Marple"
+      },
+      {
+        "title": "Patrick McKenzie Fireside Chat",
+        "hosts": "Patrick McKenzie, Zvi Mowshowitz"
+      },
+      {
+        "title": "Poker: Satellite Table #2",
+        "hosts": "David Chee"
+      },
+      {
+        "title": "Entrepreneurship in Quantification Jam Sesh",
+        "hosts": "Rai Sur"
+      },
+      {
+        "title": "Speedfriending Event #2",
+        "hosts": ""
+      },
+      {
+        "title": "Forecasting Community Discussion (with Voting)",
+        "hosts": "Nathan Young"
+      },
+      {
+        "title": "Parenting & Pronatalism",
+        "hosts": "Simone Collins, Byrne Hobart, Zvi Mowshowitz, Malcolm Collins, Rachel Weinberg"
+      },
+      {
+        "title": "Forecasting Isn't Working for Decision Makers",
+        "hosts": "Nathan Young"
+      },
+      {
+        "title": "Student Speed Networking",
+        "hosts": "Saul Munn"
+      },
+      {
+        "title": "Calibration Practice Discussion",
+        "hosts": "Raymond Arnold"
+      },
+      {
+        "title": "How to Start a Forecasting Club Fireside Chat",
+        "hosts": "Tom Shlomi, Saul Munn"
+      },
+      {
+        "title": "AI Safety Small-Group",
+        "hosts": "Emanuele Ascani"
+      },
+      {
+        "title": "Spicy Live Polling",
+        "hosts": "Aella, David Chee, Aaron Silverbook"
+      },
+      {
+        "title": "Manifold Founders Panel",
+        "hosts": "Austin Chen, James Grugett, Stephen Grugett, David Chee"
+      },
+      {
+        "title": "Speedfriending Event #3",
+        "hosts": ""
+      },
+      {
+        "title": "Good Question Tournament",
+        "hosts": "Molly Hickman, Rajashree Agrawal"
+      },
+      {
+        "title": "Whalebait Markets on Manifold",
+        "hosts": "Michael Wheatley"
+      },
+      {
+        "title": "Revolution Strategies",
+        "hosts": "Robin Hanson, David Chee"
+      },
+      {
+        "title": "Prediction Markets = Bounded Rationality?!?",
+        "hosts": "Daniel Filan"
+      },
+      {
+        "title": "Destiny vs Eliezer Debate",
+        "hosts": "Steven Bonnell II, David Chee, Aella, Nathan Young"
+      },
+      {
+        "title": "Prediction Markets as Commitment Devices",
+        "hosts": "Daniel Reeves"
+      },
+      {
+        "title": "Mafia with Markets",
+        "hosts": "Arjun Panickssery"
+      },
+      {
+        "title": "Poker Satellite Table #4 (Late Reg)",
+        "hosts": "Max Chiswick"
+      },
+      {
+        "title": "Why Prediction Markets Struggle with Politics",
+        "hosts": "Jeremiah Johnson, Steven Bonnell II, Stephen Grugett"
+      },
+      {
+        "title": "Latenight Jackbox",
+        "hosts": "Michael Tebbs (Shelvacu)"
+      },
+      {
+        "title": "Night Market & Fair",
+        "hosts": ""
+      },
+      {
+        "title": "Jazz Jam (BYO Instrument)",
+        "hosts": "Ian Philips"
+      },
+      {
+        "title": "Moderating the First User Generated Market Platform",
+        "hosts": "David Chee"
+      },
+      {
+        "title": "Team Estimation with a Traitor",
+        "hosts": "Eric Neyman"
+      }
+    ]
+  },
+  {
+    "day": "Sunday, September 24",
+    "events": [
+      {
+        "title": "Atoms and Espionage: Oppenheimer's Enigma",
+        "hosts": "Andrew Guo"
+      },
+      {
+        "title": "Reducing Bias in Education with Prediction Markets",
+        "hosts": "Simone Collins, Malcolm Collins, Rachel Weinberg"
+      },
+      {
+        "title": "Replicating Academia",
+        "hosts": "Douglas Campbell"
+      },
+      {
+        "title": "Finding Truth Without Instant Liquidity",
+        "hosts": "Andreas Finke"
+      },
+      {
+        "title": "The Future of Trust and Evidence, in the Age of AI",
+        "hosts": "Emmett Shear, Rob Miles"
+      },
+      {
+        "title": "Performative Prediction",
+        "hosts": "Johannes Treutlein"
+      },
+      {
+        "title": "Legalizing Prediction Markets",
+        "hosts": "Tarek Mansour, Pratik Chougule"
+      },
+      {
+        "title": "How AI Poker Works",
+        "hosts": "Max Chiswick"
+      },
+      {
+        "title": "Functions as Forecasts",
+        "hosts": "Ozzie Gooen, Austin Chen"
+      },
+      {
+        "title": "Polymarket Walk & Talk",
+        "hosts": "Shayne Coplan"
+      },
+      {
+        "title": "Try Out Varuna, an AI Forecaster, Built by the Former CTO and the Former Head of AI at Metaculus!",
+        "hosts": "Dan Schwarz"
+      },
+      {
+        "title": "Poker: Satellite Table #3",
+        "hosts": "David Chee"
+      },
+      {
+        "title": "Genetic Enhancement: Prediction Markets for Future People",
+        "hosts": "Jonathan Anomaly, Austin Chen"
+      },
+      {
+        "title": "Robin Hanson Office Hours",
+        "hosts": "Robin Hanson"
+      },
+      {
+        "title": "Every Platform for Debating Predictions Is Terrible; Thoughts on Fixing Them",
+        "hosts": "Eliezer Yudkowsky"
+      },
+      {
+        "title": "Balance Games and Wrestling!",
+        "hosts": "Keri Warr"
+      },
+      {
+        "title": "What's Stopping You from Doing AI Safety Advocacy?",
+        "hosts": "Holly Elmore"
+      },
+      {
+        "title": "Talk to a Theist",
+        "hosts": "Jeffrey Heninger"
+      },
+      {
+        "title": "Prediction Markets vs Financial Markets",
+        "hosts": "Byrne Hobart, Stephen Grugett"
+      },
+      {
+        "title": "Fireside Chat: ManiFund Q+A",
+        "hosts": "Elizabeth Van Nostrand, Austin Chen, Rachel Weinberg"
+      },
+      {
+        "title": "Subsidize Real Money Prediction Markets on High Impact Topics",
+        "hosts": "Ezra Brodey"
+      },
+      {
+        "title": "Proofniks / Conflux Q&A",
+        "hosts": "Jacob Cohen, Andrew Imbens, Allison Hung, Marco Angeldones"
+      },
+      {
+        "title": "Polymarket and Making Prediction Markets Mainstream",
+        "hosts": "Scott Alexander, Shayne Coplan, Zvi Mowshowitz, Pratik Chougule"
+      },
+      {
+        "title": "Lightning Talks!",
+        "hosts": "Sinclair Chen"
+      },
+      {
+        "title": "Lightning Talk: Prediction-Action Markets for Coordination",
+        "hosts": "Jason Gross"
+      },
+      {
+        "title": "Caramel Taste Test Showdown",
+        "hosts": "Matt C. Wilson, Noa Nabeshima, Lauren Milliken"
+      },
+      {
+        "title": "Nate Silver Fireside Chat",
+        "hosts": "Nate Silver, Austin Chen"
+      },
+      {
+        "title": "Biggest Questions in AI Forecasting",
+        "hosts": "Matthew Barnett"
+      },
+      {
+        "title": "Forecast Aggregation Meetup",
+        "hosts": "Gustavo Lacerda"
+      },
+      {
+        "title": "Hot Seat (Intrusive Questions Game)",
+        "hosts": "Eti Rabys"
+      },
+      {
+        "title": "Poker Tournament Finals",
+        "hosts": "David Chee"
+      },
+      {
+        "title": "Minimum Viable Yom Kippur",
+        "hosts": "Max Chiswick"
+      },
+      {
+        "title": "Improving Biomedical Research",
+        "hosts": "Gavriel Kleinwaks"
+      },
+      {
+        "title": "Descent into Dance Hell",
+        "hosts": "Aella"
+      }
+    ]
+  }
+]

--- a/public/pastsessions/events-2023.json
+++ b/public/pastsessions/events-2023.json
@@ -128,7 +128,7 @@
         "hosts": "Tom Shlomi, Saul Munn"
       },
       {
-        "title": "AI Safety Small-Group",
+        "title": "AI Safety Small Group",
         "hosts": "Emanuele Ascani"
       },
       {
@@ -180,7 +180,7 @@
         "hosts": "Jeremiah Johnson, Steven Bonnell II, Stephen Grugett"
       },
       {
-        "title": "Latenight Jackbox",
+        "title": "Late Night Jackbox",
         "hosts": ""
       },
       {
@@ -192,7 +192,7 @@
         "hosts": "Ian Philips"
       },
       {
-        "title": "Moderating the First User Generated Market Platform",
+        "title": "Moderating the First User-Generated Market Platform",
         "hosts": "David Chee"
       },
       {
@@ -285,7 +285,7 @@
         "hosts": "Elizabeth Van Nostrand, Austin Chen, Rachel Weinberg"
       },
       {
-        "title": "Subsidize Real Money Prediction Markets on High Impact Topics",
+        "title": "Subsidize Real-Money Prediction Markets on High-Impact Topics",
         "hosts": "Ezra Brodey"
       },
       {

--- a/public/pastsessions/events-2023.json
+++ b/public/pastsessions/events-2023.json
@@ -181,7 +181,7 @@
       },
       {
         "title": "Latenight Jackbox",
-        "hosts": "Michael Tebbs (Shelvacu)"
+        "hosts": ""
       },
       {
         "title": "Night Market & Fair",

--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -263,7 +263,7 @@
             "speaker": "David Chee"
           },
           {
-            "title": "How I've Had More Sex (Talk + Ama)",
+            "title": "How I've Had More Sex (Talk + AMA)",
             "speaker": "Nathan Young"
           },
           {
@@ -304,7 +304,7 @@
             "speaker": "Matt Buckley"
           },
           {
-            "title": "Doom Debates: Liron Vs. Everyone",
+            "title": "Doom Debates: Liron vs Everyone",
             "speaker": "Liron Shapira"
           },
           {
@@ -596,7 +596,7 @@
             "speaker": "Michael Lachanski"
           },
           {
-            "title": "Glp-1 Discussion Group",
+            "title": "GLP-1 Discussion Group",
             "speaker": "Andrew Rettek"
           },
           {
@@ -770,7 +770,7 @@
             "speaker": "chris (strutheo)"
           },
           {
-            "title": "Light Night Hangouts / Dance Party / Other Closing Socials",
+            "title": "Late Night Hangouts / Dance Party / Other Closing Socials",
             "speaker": "David Chee"
           }
         ]

--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -187,7 +187,7 @@
           },
           {
             "title": "Manifold Users Meetup (Day 2)",
-            "speaker": "Dylan (@Ziddletwix)"
+            "speaker": ""
           },
           {
             "title": "Poker Satellite #2",

--- a/public/pastsessions/events.json
+++ b/public/pastsessions/events.json
@@ -184,7 +184,7 @@
       },
       {
         "color": "rose",
-        "title": "Q&A with Kalshi Co-Founder & CTO, Luana Lopez",
+        "title": "Q&A with Kalshi Co-Founder & CTO, Luana Lopez Lara",
         "hosts": "Luana Lopes Lara, Noah Sternig",
         "rsvp": 32
       },
@@ -701,7 +701,7 @@
       {
         "color": "green",
         "title": "Polymarket Office Hours",
-        "hosts": "Niraek Jain-sharma",
+        "hosts": "Niraek Jain-Sharma",
         "rsvp": 19
       },
       {
@@ -772,7 +772,7 @@
       },
       {
         "color": "cyan",
-        "title": "Barbell Coaching [Venue: at the Gym]",
+        "title": "Barbell Coaching",
         "hosts": "Tzu Kit Chan",
         "rsvp": 8
       },

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Manifest Schedule — 2024 & 2025</title>
+<title>Manifest Schedule — 2023, 2024 & 2025</title>
 <style>
   @import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800;900&family=Cinzel+Decorative:wght@400;700;900&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap");
 
@@ -33,14 +33,23 @@
     border-bottom: 2px solid var(--ink);
     padding-bottom: 18px;
     margin-bottom: 20px;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
   }
   header.site h1 {
     font-family: var(--font-cinzel-deco);
     font-size: 34px;
     font-weight: 700;
-    margin: 0 0 4px;
+    margin: 0;
   }
-  header.site .sub { color: var(--muted); font-style: italic; }
+  header.site .brand {
+    font-family: var(--font-cinzel-deco);
+    font-size: 34px;
+    font-weight: 700;
+  }
 
   nav.years {
     display: flex;
@@ -76,6 +85,7 @@
   .filter-row {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 12px;
     margin: 0 0 22px;
     flex-wrap: wrap;
@@ -96,7 +106,7 @@
     background: var(--panel);
     border: 1px solid var(--rule);
     border-radius: 999px;
-    padding: 8px 32px 8px 16px;
+    padding: 14px 36px 14px 18px;
     cursor: pointer;
     appearance: none;
     -webkit-appearance: none;
@@ -218,13 +228,14 @@
 <body class="year-2025">
 <div class="wrap">
   <header class="site">
-    <h1>Manifest Schedule</h1>
-    <div class="sub">A festival of forecasting, prediction markets, and big ideas</div>
+    <h1>Schedule of Previous Years</h1>
+    <div class="brand">Manifest</div>
   </header>
 
   <nav class="years" role="tablist">
-    <button data-year="2025" class="active" role="tab" aria-selected="true">Manifest 2025</button>
-    <button data-year="2024" role="tab" aria-selected="false">Manifest 2024</button>
+    <button data-year="2025" class="active" role="tab" aria-selected="true">2025</button>
+    <button data-year="2024" role="tab" aria-selected="false">2024</button>
+    <button data-year="2023" role="tab" aria-selected="false">2023</button>
   </nav>
 
   <div id="year-meta" class="year-meta"></div>
@@ -249,6 +260,13 @@ const slugify = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/
 const META = {
   '2025': { dates: 'June 6–8, 2025' },
   '2024': { dates: 'June 7–9, 2024' },
+  '2023': { dates: 'September 22–24, 2023' },
+};
+
+const YEAR_FILES = {
+  '2025': '/pastsessions/events-2025.json',
+  '2024': '/pastsessions/events.json',
+  '2023': '/pastsessions/events-2023.json',
 };
 
 const CATEGORIES = [
@@ -345,10 +363,17 @@ function titleCase(text) {
     .replace(/\bQ&a\b/g, 'Q&A');
 }
 
+const CATEGORY_OVERRIDES = {
+  'repolarize american politics: how to make the two-party system irrelevant': 'talk',
+};
+
 function categorize(title, hosts) {
   const t = (title || '').toLowerCase();
   const h = (hosts || '').toLowerCase();
   const all = t + ' || ' + h;
+
+  const override = CATEGORY_OVERRIDES[cleanText(title).toLowerCase()];
+  if (override) return override;
 
   // Wellness — yoga, meditation, jhana, dance class, hygge, barbell
   if (/\b(yoga|meditation|guided meditation|jhana|barbell|hygge|dance class|grieving|psychological growth|meditat)/.test(t)) return 'wellness';
@@ -416,7 +441,7 @@ async function loadYear(year) {
   });
 
   const meta = META[year];
-  const data = await fetch(year === '2025' ? '/pastsessions/events-2025.json' : '/pastsessions/events.json').then(r => r.json());
+  const data = await fetch(YEAR_FILES[year]).then(r => r.json());
 
   // Year meta
   document.getElementById('year-meta').textContent = meta.dates;
@@ -489,7 +514,7 @@ function applyFilter() {
 
 filterSelect.addEventListener('change', applyFilter);
 
-const initialYear = (location.hash.match(/year-(2024|2025)/) || [,'2025'])[1];
+const initialYear = (location.hash.match(/year-(2023|2024|2025)/) || [,'2025'])[1];
 loadYear(initialYear).then(() => { refreshFilterOptions(); applyFilter(); });
 </script>
 </body>

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -228,8 +228,8 @@
 <body class="year-2025">
 <div class="wrap">
   <header class="site">
-    <h1>Schedule of Previous Years</h1>
     <div class="brand">Manifest</div>
+    <h1>Schedule of Previous Years</h1>
   </header>
 
   <nav class="years" role="tablist">

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -80,7 +80,8 @@
     font-weight: 700;
   }
 
-  .year-meta { font-size: 14px; color: var(--muted); margin-bottom: 22px; }
+  footer.site #year-meta::before { content: " · "; }
+  footer.site #year-organizers { margin-top: 4px; }
 
   .filter-row {
     display: flex;
@@ -100,13 +101,14 @@
   }
   .filter-row select {
     font-family: var(--font-cinzel);
-    font-size: 14px;
+    font-size: 15px;
+    line-height: 1.5;
     font-weight: 600;
     color: var(--ink);
     background: var(--panel);
     border: 1px solid var(--rule);
     border-radius: 999px;
-    padding: 14px 36px 14px 18px;
+    padding: 13px 36px 13px 18px;
     cursor: pointer;
     appearance: none;
     -webkit-appearance: none;
@@ -188,8 +190,9 @@
     justify-self: end;
     align-self: end;
     text-align: right;
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
   }
+  .session .speaker-name { display: inline-block; }
 
   /* Category palette — soft pastels */
   .session[data-cat="talk"]      { background: #edf5fa; border-color: #d6e8f2; }
@@ -238,8 +241,6 @@
     <button data-year="2023" role="tab" aria-selected="false">2023</button>
   </nav>
 
-  <div id="year-meta" class="year-meta"></div>
-
   <div class="filter-row">
     <label for="cat-filter">Filter by type</label>
     <select id="cat-filter">
@@ -251,6 +252,8 @@
 
   <footer class="site">
     <span id="footer-text"></span>
+    <span id="year-meta"></span>
+    <div id="year-organizers"></div>
   </footer>
 </div>
 
@@ -258,9 +261,9 @@
 const slugify = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
 const META = {
-  '2025': { dates: 'June 6–8, 2025' },
-  '2024': { dates: 'June 7–9, 2024' },
-  '2023': { dates: 'September 22–24, 2023' },
+  '2025': { dates: 'June 6–8, 2025', organizers: 'David Chee & Rachel Farley' },
+  '2024': { dates: 'June 7–9, 2024', organizers: 'Saul Munn & Rachel Weinberg' },
+  '2023': { dates: 'September 22–24, 2023', organizers: 'Saul Munn & David Chee' },
 };
 
 const YEAR_FILES = {
@@ -323,6 +326,7 @@ function titleCase(text) {
   const acronyms = {
     ai: 'AI',
     agi: 'AGI',
+    aisi: 'AISI',
     api: 'API',
     ea: 'EA',
     gpt: 'GPT',
@@ -331,10 +335,13 @@ function titleCase(text) {
     llm: 'LLM',
     llms: 'LLMs',
     mats: 'MATS',
+    nhk: 'NHK',
     nsfw: 'NSFW',
+    optic: 'OPTIC',
     qna: 'Q&A',
     'q&a': 'Q&A',
     rsvp: 'RSVP',
+    uk: 'UK',
     usa: 'USA',
   };
 
@@ -428,7 +435,16 @@ function createSessionCard(session) {
     <div class="speaker"></div>`;
   card.querySelector('.cat-label').textContent = CAT_LABEL[cat] || cat;
   card.querySelector('.title').textContent = titleCase(session.title);
-  card.querySelector('.speaker').textContent = session.speaker;
+  const speakerEl = card.querySelector('.speaker');
+  const names = (session.speaker || '').split(',').map(s => s.trim()).filter(Boolean);
+  speakerEl.textContent = '';
+  names.forEach((name, i) => {
+    const span = document.createElement('span');
+    span.className = 'speaker-name';
+    span.textContent = name;
+    speakerEl.appendChild(span);
+    if (i < names.length - 1) speakerEl.appendChild(document.createElement('br'));
+  });
   return { card, cat };
 }
 
@@ -446,6 +462,7 @@ async function loadYear(year) {
   // Year meta
   document.getElementById('year-meta').textContent = meta.dates;
   document.getElementById('footer-text').textContent = `Manifest ${year}`;
+  document.getElementById('year-organizers').textContent = meta.organizers;
 
   // Render schedule
   const catOrder = Object.fromEntries(CATEGORIES.map((c, i) => [c.key, i]));

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -193,6 +193,10 @@
     overflow-wrap: break-word;
   }
   .session .speaker-name { display: inline-block; }
+  .session a.speaker-name { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
+  .session a.speaker-name:hover { color: var(--ink); border-bottom-style: solid; }
+  footer.site a { color: inherit; text-decoration: underline; text-decoration-color: var(--rule); }
+  footer.site a:hover { text-decoration-color: currentColor; }
 
   /* Category palette — soft pastels */
   .session[data-cat="talk"]      { background: #edf5fa; border-color: #d6e8f2; }
@@ -261,9 +265,9 @@
 const slugify = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
 const META = {
-  '2025': { dates: 'June 6–8, 2025', organizers: 'David Chee & Rachel Farley' },
-  '2024': { dates: 'June 7–9, 2024', organizers: 'Saul Munn & Rachel Weinberg' },
-  '2023': { dates: 'September 22–24, 2023', organizers: 'Saul Munn & David Chee' },
+  '2025': { dates: 'June 6–8, 2025', organizers: 'David Chee, Rachel Farley & Austin Chen' },
+  '2024': { dates: 'June 7–9, 2024', organizers: 'Saul Munn, Rachel Weinberg & Austin Chen' },
+  '2023': { dates: 'September 22–24, 2023', organizers: 'Saul Munn, David Chee & Austin Chen' },
 };
 
 const YEAR_FILES = {
@@ -330,6 +334,7 @@ function titleCase(text) {
     api: 'API',
     ea: 'EA',
     gpt: 'GPT',
+    'glp-1': 'GLP-1',
     lgbt: 'LGBT',
     lgbtq: 'LGBTQ',
     llm: 'LLM',
@@ -373,6 +378,8 @@ function titleCase(text) {
 const CATEGORY_OVERRIDES = {
   'repolarize american politics: how to make the two-party system irrelevant': 'talk',
 };
+
+const SPEAKER_LINKS = {};
 
 function categorize(title, hosts) {
   const t = (title || '').toLowerCase();
@@ -439,10 +446,16 @@ function createSessionCard(session) {
   const names = (session.speaker || '').split(',').map(s => s.trim()).filter(Boolean);
   speakerEl.textContent = '';
   names.forEach((name, i) => {
-    const span = document.createElement('span');
-    span.className = 'speaker-name';
-    span.textContent = name;
-    speakerEl.appendChild(span);
+    const url = SPEAKER_LINKS[name];
+    const el = document.createElement(url ? 'a' : 'span');
+    el.className = 'speaker-name';
+    el.textContent = name;
+    if (url) {
+      el.href = url;
+      el.target = '_blank';
+      el.rel = 'noopener noreferrer';
+    }
+    speakerEl.appendChild(el);
     if (i < names.length - 1) speakerEl.appendChild(document.createElement('br'));
   });
   return { card, cat };
@@ -462,7 +475,20 @@ async function loadYear(year) {
   // Year meta
   document.getElementById('year-meta').textContent = meta.dates;
   document.getElementById('footer-text').textContent = `Manifest ${year}`;
-  document.getElementById('year-organizers').textContent = meta.organizers;
+  const orgEl = document.getElementById('year-organizers');
+  orgEl.textContent = '';
+  meta.organizers.split(/\s*[,&]\s*/).forEach((name, i, arr) => {
+    const url = SPEAKER_LINKS[name];
+    const el = document.createElement(url ? 'a' : 'span');
+    el.textContent = name;
+    if (url) {
+      el.href = url;
+      el.target = '_blank';
+      el.rel = 'noopener noreferrer';
+    }
+    orgEl.appendChild(el);
+    if (i < arr.length - 1) orgEl.appendChild(document.createElement('br'));
+  });
 
   // Render schedule
   const catOrder = Object.fromEntries(CATEGORIES.map((c, i) => [c.key, i]));


### PR DESCRIPTION
## Summary
- Adds a Manifest 2023 tab with the full Sep 22–24, 2023 schedule (`public/pastsessions/events-2023.json`, 82 sessions across 3 days)
- Refreshes the page header: "Schedule of Previous Years" left-aligned, "Manifest" right-aligned; year tabs now read just "2025/2024/2023"
- Right-aligns the type filter and bumps its height so it reads as a proper control
- Adds a small `CATEGORY_OVERRIDES` map to fix one auto-categorizer miss ("Repolarize American Politics" was being tagged social/workshop instead of talk)

## Test plan
- [ ] Open `/pastsessions` and switch between 2025 / 2024 / 2023 tabs — each loads its day sections and the filter dropdown repopulates
- [ ] On 2024, confirm "Repolarize American Politics: How to Make the Two-Party System Irrelevant" now appears under Talk / Lecture
- [ ] Confirm header layout (left/right) and filter row right-alignment look right on desktop and wrap cleanly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)