### PR TITLE
Tighten past session hide rules

### DIFF
--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -371,12 +371,11 @@ const HIDE_PATTERNS = [
   /\bregistration\b/i,
   /\bvolunteer training\b/i,
   /\bbreak\b/i,
-  /\bclosing\b/i,
+  /\bclosing (ceremony|circle)\b/i,
+  /\bdinner & closing ceremony\b/i,
   /^\s*\[blocked/i,
   /^\s*reserved\s*$/i,
-  /\boverflow\b/i,
   /\bjudges huddle\b/i,
-  /pitch competition (judges|setup)/i,
 ];
 function shouldHide(title) {
   const t = title || '';


### PR DESCRIPTION
## Summary
- avoid hiding real sessions that contain overflow/setup/closing in their title
- keep placeholder hides for Reserved and Pitch competition judges huddle
- restore visibility for Speedfriending overflow, Question overflow, Pitch competition setup/Rapid fire tips for founders, and the 2024 AI Threat Modeling talk

## Verification
- audited every hidden session across 2023, 2024, and 2025
- verified restored sessions are visible and 45 expected category fixes still pass