### PR TITLE
Combine Substack CEO and Chris Best into one line

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -721,8 +721,7 @@ const PAGE_HTML = `
         <li><b>Stephen Grugett &amp; Theo Jaffee</b></li>
         <li><b>Ajeya Cotra</b></li>
         <li><b>Kalshi Co-Founder, Luana Lopes Lara</b></li>
-        <li><b>Substack CEO</b></li>
-        <li><b>Chris Best</b></li>
+        <li><b>Substack CEO, Chris Best</b></li>
         <li><b>David Shor &amp; Jesse Richardson</b></li>
       </ol>
     </article>


### PR DESCRIPTION
## Summary
- Merge "Substack CEO" and "Chris Best" Firesides entries into a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)