### PR TITLE
Merge Office Hours back into the demo category

### DIFF
--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -348,8 +348,7 @@ const CATEGORIES = [
   { key: 'performance', label: 'Performance / Comedy' },
   { key: 'panel',       label: 'Panel / Q&A / Fireside' },
   { key: 'workshop',    label: 'Workshop / Class'     },
-  { key: 'demo',        label: 'Demo'                 },
-  { key: 'office',      label: 'Office Hours'         },
+  { key: 'demo',        label: 'Demo / Office Hours'  },
   { key: 'talk',        label: 'Talk / Lecture'       },
 ];
 
@@ -555,8 +554,8 @@ function categorize(title, hosts) {
   if (/\b(poker|chess|bughouse|trivia|tournament|clocktower|game show|cardinality|sock wrestle|origami|estimation game|nash pit|operant conditioning game|crystal coinflip|dumb pitch|pitch competition|startup pitch|speed friending|speed meeting|speedfriend|mentor.*mentee)\b/.test(t)) return 'game';
   // Social — meetup, mixer, party, hangout, gathering, social, friends, lgbt, parents, founders meetup
   if (/\b(meetup|mixer|party|hangout|gathering|social|meet[\s-]?up|friends?|lgbt|gay|parents meetup|founders meetup|shabbat|whales|degens|mira|founders meetup)\b/.test(all)) return 'social';
-  // Office Hours — anything titled "... Office Hours"
-  if (/\boffice hours\b/.test(t)) return 'office';
+  // Office Hours — always route to demo, even if title also matches workshop (e.g. Build-A-Bot Office Hours)
+  if (/\boffice hours\b/.test(t)) return 'demo';
   // Q&A / Fireside / Panel
   if (/\b(q&a|q ?and ?a|fireside|panel|debate|interviews?|conversation|discussion)\b/.test(t)) return 'panel';
   // Workshop / class / training / build-a-bot / lesson


### PR DESCRIPTION
## Summary
- Reverts the separate \`office\` category from #40
- Restores demo's label to "Demo / Office Hours" and routes any "... Office Hours" title to \`demo\`
- Adds an early-return check before the workshop regex so titles like "Metaculus Build-A-Bot Office Hours" don't get pulled into workshop via \`build-a-bot\`

## Test plan
- [x] Local verifier: Robin Hanson / Kalshi / Sovereign / Polymarket / Metaculus Build-A-Bot Office Hours all return \`demo\`
- [x] Regression: previously-correct entries (Bughouse Chess, Robot Meetup, Build a Trading Bot Workshop, Pitch competition setup/Rapid fire tips for founders, Warcasting: Taiwan) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)