### PR TITLE
Restyle past session cards with stacked layout

### DIFF
--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -149,16 +149,17 @@
   .session {
     background: var(--card);
     border: 1px solid var(--rule);
-    padding: 10px 12px;
+    padding: 16px;
     border-radius: 6px;
     transition: transform 100ms;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(96px, 38%);
-    grid-template-rows: auto 1fr;
-    gap: 2px 12px;
-    min-height: 86px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: auto 1fr auto;
+    column-gap: 12px;
+    row-gap: 12px;
+    min-height: 132px;
     break-inside: avoid;
-    margin: 0 0 10px;
+    margin: 0 0 12px;
   }
   .session:hover { transform: translateY(-1px); }
   #session-tooltip {
@@ -209,16 +210,19 @@
     font-weight: 600;
     color: #5d5547;
     opacity: 0.7;
-    margin-bottom: 6px;
     grid-column: 1;
     grid-row: 1;
-    align-self: start;
+    align-self: center;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .session .rsvp {
     grid-column: 2;
     grid-row: 1;
     justify-self: end;
-    align-self: start;
+    align-self: center;
     display: inline-flex;
     align-items: center;
     gap: 4px;
@@ -239,22 +243,27 @@
   .session .title {
     font-size: 12px;
     font-weight: 700;
-    margin-bottom: 0;
     color: #2b2419;
     line-height: 1.28;
-    grid-column: 1;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    min-height: calc(12px * 1.28 * 3);
   }
   .session .speaker {
     font-family: var(--font-cinzel);
     font-size: 12px;
     color: #5d5547;
     font-style: italic;
-    grid-column: 2;
-    grid-row: 2;
-    justify-self: end;
-    align-self: end;
-    text-align: right;
+    grid-column: 1 / -1;
+    grid-row: 3;
+    text-align: left;
     overflow-wrap: break-word;
+    line-height: 1.35;
   }
   .session .speaker-name { display: inline-block; white-space: nowrap; }
   .session a.speaker-name { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
@@ -286,13 +295,6 @@
     header.site h1 { font-size: 28px; }
     h2.day { font-size: 22px; }
     .session-grid { column-count: 1; }
-    .session { grid-template-columns: minmax(0, 1fr); }
-    .session .speaker {
-      grid-column: 1;
-      grid-row: auto;
-      justify-self: start;
-      text-align: left;
-    }
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Switches session cards from a two-column (title left, speaker right) layout to a stacked grid: category label + RSVP on top, 3-line clamped title in the middle, speaker name on its own bottom row
- Bumps padding to 16px and min-height to 132px for a more uniform grid; drops the now-redundant mobile grid override

## Test plan
- [ ] Visual spot-check `/pastsessions` for 2023 / 2024 / 2025 in the Vercel preview, including long titles (3-line clamp) and multi-speaker rows
- [ ] Mobile (single-column) layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)