### PR TITLE
Restyle past session cards with three-region layout and host formatting

### DIFF
--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -178,15 +178,6 @@
         "description": "When coastal cities throughout the world ran out of land, they used to make more through reclamation: using dikes and fill materials to turn water into land. In the United States, though, we haven't done this at scale for half a century. I'll tell you the history of land reclamation, how and why it stopped in the United States, and why there's a strong economic case for starting land reclamation again."
       },
       {
-        "title": "Night Market & Career Fair",
-        "hosts": "David Chee",
-        "rsvp": 96,
-        "venue": "Rat Park",
-        "start": "7:30 PM",
-        "end": "8:30 PM",
-        "description": "Tons of free swag from sponsors, booths from attendees, opportunities to talk with companies hiring. Doors will also open to the public for free starting at 8pm."
-      },
-      {
         "title": "Slutstack pod",
         "hosts": "Chesed",
         "rsvp": 1,
@@ -236,14 +227,6 @@
         "venue": "Rat Park",
         "start": "8:30 PM",
         "end": "8:45 PM"
-      },
-      {
-        "title": "Night Market",
-        "hosts": "Rach",
-        "rsvp": 27,
-        "venue": "Rat Park",
-        "start": "8:45 PM",
-        "end": "10:00 PM"
       },
       {
         "title": "Are prediction markets a dead end?",

--- a/public/pastsessions/events.json
+++ b/public/pastsessions/events.json
@@ -5,7 +5,7 @@
       {
         "color": "rose",
         "title": "Manifold Theater: Sweepstakes Mania (feat. Duncan Horst of Bet on Love)",
-        "hosts": "Duncan Horst, Tim Blais",
+        "hosts": "Tim Blais & Duncan Horst",
         "rsvp": 60,
         "venue": "Rat Park",
         "start": "4:30 PM",
@@ -35,7 +35,7 @@
       {
         "color": "orange",
         "title": "Fireside Chat with Founder of Upstart, Paul Gu",
-        "hosts": "Paul Gu, Austin Chen",
+        "hosts": "Paul Gu & Austin Chen",
         "rsvp": 21,
         "venue": "Eigen Hall",
         "start": "4:30 PM",
@@ -54,7 +54,7 @@
       {
         "color": "orange",
         "title": "The Politics of Election Market Bans",
-        "hosts": "Jeremiah Johnson, Maxim Lott, Peter Hammon",
+        "hosts": "Jeremiah Johnson & Maxim Lott & Peter Hammon",
         "rsvp": 68,
         "venue": "Eigen Hall",
         "start": "7:00 PM",
@@ -154,7 +154,7 @@
       {
         "color": "lime",
         "title": "Theo Jaffee Interviews Stephen Grugett",
-        "hosts": "Stephen Grugett, Theodore Jaffee",
+        "hosts": "Stephen Grugett & Theodore Jaffee",
         "rsvp": 34,
         "venue": "Bayes Attic",
         "start": "8:00 PM",
@@ -407,7 +407,7 @@
       {
         "color": "rose",
         "title": "Why So Much Disagreement About AI Risk?",
-        "hosts": "Josh Rosenberg, Scott Alexander, Misha Glouberman",
+        "hosts": "Josh Rosenberg & Scott Alexander & Misha Glouberman",
         "rsvp": 131,
         "venue": "Rat Park",
         "start": "1:00 PM",
@@ -417,7 +417,7 @@
       {
         "color": "rose",
         "title": "Fireside Chat with Substack CEO, Chris Best",
-        "hosts": "Chris Best, Austin Chen",
+        "hosts": "Chris Best & Austin Chen",
         "rsvp": 104,
         "venue": "Rat Park",
         "start": "2:00 PM",
@@ -464,7 +464,7 @@
       {
         "color": "orange",
         "title": "Metaculus: $120K AI Benchmarking Tournament Announcement & Build-A-Bot Workshop",
-        "hosts": "Deger Turan, Tom Liptay",
+        "hosts": "Tom Liptay & Deger Turan",
         "rsvp": 48,
         "venue": "Eigen Hall",
         "start": "11:00 AM",
@@ -483,7 +483,7 @@
       {
         "color": "orange",
         "title": "Hard Questions for Manifold",
-        "hosts": "Stephen Grugett, James Grugett, Austin Chen",
+        "hosts": "Austin Chen, James Grugett & Stephen Grugett",
         "rsvp": 56,
         "venue": "Eigen Hall",
         "start": "1:00 PM",
@@ -773,7 +773,7 @@
       {
         "color": "green",
         "title": "Founders Meetup",
-        "hosts": "Jonathan Miller, Yingru Qiu",
+        "hosts": "Yingru Qiu & Jonathan Miller",
         "rsvp": 24,
         "venue": "Gyroscope",
         "start": "10:00 AM",
@@ -783,7 +783,7 @@
       {
         "color": "green",
         "title": "Events Should Be Good, Not Bad",
-        "hosts": "Austin Chen, Misha Glouberman",
+        "hosts": "Austin Chen & Misha Glouberman",
         "rsvp": 48,
         "venue": "Gyroscope",
         "start": "11:00 AM",
@@ -813,7 +813,7 @@
       {
         "color": "green",
         "title": "Futarchy and Conditional Markets",
-        "hosts": "Kelvin Santos, Robin Hanson, Austin Chen",
+        "hosts": "Austin Chen, Robin Hanson & Kelvin Santos",
         "rsvp": 58,
         "venue": "Gyroscope",
         "start": "3:00 PM",
@@ -1055,7 +1055,7 @@
       },
       {
         "title": "Emergent gameplay and narrative",
-        "hosts": "Patrick McKenzie, Justin Kuiper",
+        "hosts": "Justin Kuiper & Patrick McKenzie",
         "rsvp": 51,
         "venue": "Gyroscope",
         "start": "1:00 PM",
@@ -1064,7 +1064,7 @@
       },
       {
         "title": "Banking + Dragons: analyzing The Dagger and the Coin",
-        "hosts": "Patrick McKenzie, Justin Kuiper",
+        "hosts": "Justin Kuiper & Patrick McKenzie",
         "rsvp": 31,
         "venue": "Gyroscope",
         "start": "1:30 PM",
@@ -1240,7 +1240,7 @@
       },
       {
         "title": "Draw Bluey",
-        "hosts": "keltan O’Shea, Isabella Jones, Isaac Henry Linn, August Veix",
+        "hosts": "August Veix & keltan O’Shea & Isabella Jones & Isaac Henry Linn",
         "rsvp": 7,
         "venue": "Bayes Ground",
         "start": "11:00 PM",
@@ -1294,7 +1294,7 @@
       {
         "color": "rose",
         "title": "Behind the Numbers: Eliciting Rationales to Improve Decision-Making",
-        "hosts": "Cate Hall, Dan Schwarz, Josh Rosenberg, Deger Turan",
+        "hosts": "Cate Hall & Dan Schwarz & Deger Turan & Josh Rosenberg",
         "rsvp": 61,
         "venue": "Rat Park",
         "start": "1:00 PM",
@@ -1747,7 +1747,7 @@
       },
       {
         "title": "Starting a Microschool: An interview with Kelsey Piper and June Kreml",
-        "hosts": "Jasmine Ren, Kelsey Piper, June Kreml",
+        "hosts": "June Kreml & Jasmine Ren & Kelsey Piper",
         "rsvp": 85,
         "venue": "Eigen Hall",
         "start": "9:30 AM",
@@ -1993,7 +1993,7 @@
       },
       {
         "title": "<in the rat park dome> Church",
-        "hosts": "Lydia La Roux, Ian Phillips, Robin Hanson, Sy Etirabys",
+        "hosts": "Sy Etirabys & Ian Phillips & Robin Hanson & Lydia La Roux",
         "rsvp": 9,
         "venue": "Bayes Attic",
         "start": "8:00 PM",

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -149,18 +149,22 @@
   .session {
     background: var(--card);
     border: 1px solid var(--rule);
-    padding: 10px 12px;
+    padding: 8px 10px;
     border-radius: 6px;
     transition: transform 100ms;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(96px, 38%);
-    grid-template-rows: auto 1fr;
-    gap: 2px 12px;
-    min-height: 86px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
     break-inside: avoid;
-    margin: 0 0 10px;
+    margin: 0 0 8px;
   }
   .session:hover { transform: translateY(-1px); }
+  .session__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+  }
   #session-tooltip {
     position: fixed;
     display: none;
@@ -209,16 +213,14 @@
     font-weight: 600;
     color: #5d5547;
     opacity: 0.7;
-    margin-bottom: 6px;
-    grid-column: 1;
-    grid-row: 1;
-    align-self: start;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .session .rsvp {
-    grid-column: 2;
-    grid-row: 1;
-    justify-self: end;
-    align-self: start;
+    flex: 0 0 auto;
     display: inline-flex;
     align-items: center;
     gap: 4px;
@@ -239,22 +241,24 @@
   .session .title {
     font-size: 12px;
     font-weight: 700;
-    margin-bottom: 0;
     color: #2b2419;
     line-height: 1.28;
-    grid-column: 1;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
   .session .speaker {
     font-family: var(--font-cinzel);
     font-size: 12px;
     color: #5d5547;
     font-style: italic;
-    grid-column: 2;
-    grid-row: 2;
-    justify-self: end;
-    align-self: end;
     text-align: right;
+    align-self: stretch;
     overflow-wrap: break-word;
+    line-height: 1.25;
+    margin-top: 3px;
   }
   .session .speaker-name { display: inline-block; white-space: nowrap; }
   .session a.speaker-name { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
@@ -286,13 +290,6 @@
     header.site h1 { font-size: 28px; }
     h2.day { font-size: 22px; }
     .session-grid { column-count: 1; }
-    .session { grid-template-columns: minmax(0, 1fr); }
-    .session .speaker {
-      grid-column: 1;
-      grid-row: auto;
-      justify-self: start;
-      text-align: left;
-    }
   }
 </style>
 </head>
@@ -460,6 +457,7 @@ const CATEGORY_OVERRIDES = {
   'awkwardmaxxing for the socially anxious': 'workshop',
   'balance games and wrestling!': 'game',
   'banterbrush: chill, chat and make art': 'social',
+  'behind the numbers: eliciting rationales to improve decision-making': 'panel',
   'big manifold awards ceremony': 'performance',
   'breaking the blank slate: social consequences of genetic screening': 'talk',
   'build the future of universities with me': 'workshop',
@@ -476,6 +474,7 @@ const CATEGORY_OVERRIDES = {
   'draw bluey': 'social',
   'epic math puzzle sesh': 'game',
   'experimental conversational format': 'social',
+  'emergent gameplay and narrative': 'panel',
   'figgie': 'game',
   'fine-tuning, the multiverse, anthropic bias, and the reference-class problem': 'panel',
   'fire 101 & hidden traps': 'talk',
@@ -599,13 +598,15 @@ function createSessionCard(session) {
   const cat = categorize(session.title, session.speaker);
   card.dataset.cat = cat;
   card.innerHTML = `
-    <div class="cat-label"></div>
-    <div class="rsvp">
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <circle cx="12" cy="8" r="4"/>
-        <path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/>
-      </svg>
-      <span class="rsvp-count"></span>
+    <div class="session__top">
+      <div class="cat-label"></div>
+      <div class="rsvp">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="8" r="4"/>
+          <path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/>
+        </svg>
+        <span class="rsvp-count"></span>
+      </div>
     </div>
     <div class="title"></div>
     <div class="speaker"></div>`;
@@ -630,20 +631,34 @@ function createSessionCard(session) {
     card.tabIndex = 0;
   }
   const speakerEl = card.querySelector('.speaker');
-  const names = (session.speaker || '').split(',').map(s => s.trim()).filter(Boolean);
+  let groups = (session.speaker || '').split(',').map(s => s.trim()).filter(Boolean);
+  groups.sort((a, b) => a.length - b.length);
+  if (groups.length === 2 && !groups[0].includes('&') && !groups[1].includes('&')) {
+    groups = [groups.join(' & ')];
+  }
   speakerEl.textContent = '';
-  names.forEach((name, i) => {
-    const url = SPEAKER_LINKS[name];
-    const el = document.createElement(url ? 'a' : 'span');
-    el.className = 'speaker-name';
-    el.textContent = name;
-    if (url) {
-      el.href = url;
-      el.target = '_blank';
-      el.rel = 'noopener noreferrer';
-    }
-    speakerEl.appendChild(el);
-    if (i < names.length - 1) speakerEl.appendChild(document.createElement('br'));
+  groups.forEach((group, gi) => {
+    const subnames = group.split(/\s*&\s*/).map(s => s.trim()).filter(Boolean).sort((a, b) => a.length - b.length);
+    subnames.forEach((name, si) => {
+      if (si > 0) {
+        let sep;
+        if (subnames.length === 2) sep = ' & ';
+        else if (si === subnames.length - 1) sep = ', & ';
+        else sep = ', ';
+        speakerEl.appendChild(document.createTextNode(sep));
+      }
+      const url = SPEAKER_LINKS[name];
+      const el = document.createElement(url ? 'a' : 'span');
+      el.className = 'speaker-name';
+      el.textContent = name;
+      if (url) {
+        el.href = url;
+        el.target = '_blank';
+        el.rel = 'noopener noreferrer';
+      }
+      speakerEl.appendChild(el);
+    });
+    if (gi < groups.length - 1) speakerEl.appendChild(document.createElement('br'));
   });
   return { card, cat };
 }

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -149,17 +149,16 @@
   .session {
     background: var(--card);
     border: 1px solid var(--rule);
-    padding: 16px;
+    padding: 10px 12px;
     border-radius: 6px;
     transition: transform 100ms;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-rows: auto 1fr auto;
-    column-gap: 12px;
-    row-gap: 12px;
-    min-height: 132px;
+    grid-template-columns: minmax(0, 1fr) minmax(96px, 38%);
+    grid-template-rows: auto 1fr;
+    gap: 2px 12px;
+    min-height: 86px;
     break-inside: avoid;
-    margin: 0 0 12px;
+    margin: 0 0 10px;
   }
   .session:hover { transform: translateY(-1px); }
   #session-tooltip {
@@ -210,19 +209,16 @@
     font-weight: 600;
     color: #5d5547;
     opacity: 0.7;
+    margin-bottom: 6px;
     grid-column: 1;
     grid-row: 1;
-    align-self: center;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    align-self: start;
   }
   .session .rsvp {
     grid-column: 2;
     grid-row: 1;
     justify-self: end;
-    align-self: center;
+    align-self: start;
     display: inline-flex;
     align-items: center;
     gap: 4px;
@@ -243,27 +239,22 @@
   .session .title {
     font-size: 12px;
     font-weight: 700;
+    margin-bottom: 0;
     color: #2b2419;
     line-height: 1.28;
-    grid-column: 1 / -1;
-    grid-row: 2;
-    margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    min-height: calc(12px * 1.28 * 3);
+    grid-column: 1;
   }
   .session .speaker {
     font-family: var(--font-cinzel);
     font-size: 12px;
     color: #5d5547;
     font-style: italic;
-    grid-column: 1 / -1;
-    grid-row: 3;
-    text-align: left;
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: end;
+    align-self: end;
+    text-align: right;
     overflow-wrap: break-word;
-    line-height: 1.35;
   }
   .session .speaker-name { display: inline-block; white-space: nowrap; }
   .session a.speaker-name { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
@@ -295,6 +286,13 @@
     header.site h1 { font-size: 28px; }
     h2.day { font-size: 22px; }
     .session-grid { column-count: 1; }
+    .session { grid-template-columns: minmax(0, 1fr); }
+    .session .speaker {
+      grid-column: 1;
+      grid-row: auto;
+      justify-self: start;
+      text-align: left;
+    }
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Refactor each session card to a compact 3-region flex-column layout (top row with category label + RSVP, 3-line clamped title, right-aligned speaker block)
- Establish a host-string convention: comma -> new line, `&` -> same line; 2-host comma lists auto-pair; 3+ names in an `&` group render Oxford-comma style; names sorted shortest-first
- Apply per-card host overrides for ~17 cards and categorize "Behind the Numbers" and "Emergent gameplay and narrative" as panel
- Remove duplicate 2025 "Night Market" (Rach) and "Night Market & Career Fair" entries

## Test plan
- [ ] Load `/pastsessions/`, switch between 2025 / 2024 / 2023 tabs - cards in each year render with the new layout
- [ ] Long titles clamp at 3 lines and do not overlap the speaker block
- [ ] Speaker names appear bottom-right; multi-host cards render per the `&` / comma rules
- [ ] Category filter dropdown still works; "Behind the Numbers" and "Emergent gameplay and narrative" appear under Panel / Q&A / Fireside
- [ ] Removed Night Market entries no longer show up
