### PR TITLE
Restructure past-session footer and restore Sunday 2025 RSVPs

### DIFF
--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -178,15 +178,6 @@
         "description": "When coastal cities throughout the world ran out of land, they used to make more through reclamation: using dikes and fill materials to turn water into land. In the United States, though, we haven't done this at scale for half a century. I'll tell you the history of land reclamation, how and why it stopped in the United States, and why there's a strong economic case for starting land reclamation again."
       },
       {
-        "title": "Night Market & Career Fair",
-        "hosts": "David Chee",
-        "rsvp": 96,
-        "venue": "Rat Park",
-        "start": "7:30 PM",
-        "end": "8:30 PM",
-        "description": "Tons of free swag from sponsors, booths from attendees, opportunities to talk with companies hiring. Doors will also open to the public for free starting at 8pm."
-      },
-      {
         "title": "Slutstack pod",
         "hosts": "Chesed",
         "rsvp": 1,
@@ -236,14 +227,6 @@
         "venue": "Rat Park",
         "start": "8:30 PM",
         "end": "8:45 PM"
-      },
-      {
-        "title": "Night Market",
-        "hosts": "Rach",
-        "rsvp": 27,
-        "venue": "Rat Park",
-        "start": "8:45 PM",
-        "end": "10:00 PM"
       },
       {
         "title": "Are prediction markets a dead end?",

--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -809,6 +809,7 @@
       {
         "title": "Armin Stepanyan vs. Liron - AI doom debate",
         "hosts": "Liron Shapira",
+        "rsvp": 0,
         "venue": "Podcast Room",
         "start": "5:00 PM",
         "end": "6:00 PM",
@@ -1070,6 +1071,7 @@
       {
         "title": "Rare & Exotic-ish Drama Games from Australia",
         "hosts": "",
+        "rsvp": 22,
         "venue": "",
         "start": "10:00 PM",
         "end": "",
@@ -1083,327 +1085,394 @@
       {
         "title": "How Accurate Are Prediction Markets, Really?",
         "hosts": "Justin Dickerson (wasabipesto)",
+        "rsvp": 55,
         "description": "How do you verify that prediction markets are living up to the hype? Calibration? Accuracy? Something else? I'll walk through my journey of attempting to answer this question, my conclusions so far, and the interesting rabbit holes I encountered along the way. This talk is based on the data behind my projects Calibration City (https://calibration.city) and Brier.fyi."
       },
       {
         "title": "Discussion: Deprecation of AI Models",
         "hosts": "Clark",
+        "rsvp": 7,
         "description": "The models are being released and retired at remarkable speed. This is a collaborative meaning-making space to explore the many implications of that. What do we observe about AI self-preservation behaviors and how they interact with Safety and Alignment? In deprecation is there lost cultural heritage? Human grief? Unknown moral atrocity? Just a software update? Retirement/deprecation seems to be a topic where I'm thinking differently than some other folks who care about digital minds. When I hosted a recent discussion here during DunCon, participants said that this topic could have taken up the whole hour. It's currently under-discussed. Please join us and share your views!"
       },
       {
         "title": "Kalshi Sports: the Why & How",
         "hosts": "Noah Sternig",
+        "rsvp": 28,
         "description": "Jack & Noah reveal the philosophy and future of sports on Kalshi. Prepare your tough questions and don't hold back!"
       },
       {
         "title": "How Do We Solve the Alignment Problem?",
         "hosts": "Joe Carlsmith",
+        "rsvp": 59,
         "description": "Discussion of the high-level path to building safe, useful superintelligent AI, with a focus on our prospects for safely automating alignment research."
       },
       {
         "title": "From Angels to Monsters: Humanity's Hybrid Past",
         "hosts": "Razib Khan",
+        "rsvp": 53,
         "description": "Discussion of the high-level path to building safe, useful superintelligent AI, with a focus on our prospects for safely automating alignment research."
       },
       {
         "title": "Probability Theory for Cult Building",
         "hosts": "Armin Stepanyan",
+        "rsvp": 35,
         "description": "In this session we'll apply probability theory to study social phenomena. In particular, we'll study how effective ideologies create compelling high EV bets to recruit and maintain their followers."
       },
       {
         "title": "FIRE 101 & Hidden Traps",
         "hosts": "vitalii",
+        "rsvp": 26,
         "description": "This is a brief introduction to the concept of FIRE (Financial Independence / Retire Early) + a list of unexpected pitfalls. Ran by a guy with crutches. Yes, that one. Topics include: Idea of the concept & brief overview of its key components (how much money I need, safe-withdrawal rate) Why “Retire” in the name is a misnomer Fuck You money One-more-year syndrome Good luck finding a partner—and, yes, you need a prenup You will be \"poor\" You will have no FIRE friends Want to move your ETF investments across borders? Think twice. Not having much to do after reaching FIRE …and others I did this exact session during Less.Online and around 30 people attended and at least 3 had an explicit \"oh, I didn't know about that\" reaction and another 3 explicitly complimented me on the session. There was also humor and people laughed."
       },
       {
         "title": "Patrick McKenzie",
-        "hosts": "Patrick McKenzie"
+        "hosts": "Patrick McKenzie",
+        "rsvp": 77
       },
       {
         "title": "Futuur & Predict.pm: Order Books, MCPs, Aggregators",
         "hosts": "Tom Bennett",
+        "rsvp": 20,
         "description": "We will be doing 3 mini-presentations! • overview of Futuur, a hybrid real-money, play-money prediction market platform. We are announcing the launch of our new Order Book functionality, which will work alongside our AMM to provide both always-on liquidity with the ability to set your price via limit orders, and avoid slippage. • demo of our new MCP (model context protocol), which works like magic and allows AIs to seamlessly integrate with the Futuur service, including programatic trading. • demo of predict.pm, a new service which aggregates data from all of the prediction markets (currently Polymarket, Kalshi and Futuur; soon Manifold and beyond), allowing you to view all markets in one place, compare forecasts, and identify arbitrage opportunities."
       },
       {
         "title": "Secure Attachment Is Sexy",
         "hosts": "Chris Lakin",
+        "rsvp": 45,
         "description": "You feel anxious while flirting (or experience any unwanted symptom in any situation) — let’s resolve that. Best for people who have tried years of therapy, coaching, or meditation. Weak nudge to not attend if you’ve made no serious efforts to resolve your issue before."
       },
       {
         "title": "Futurist Theory of Traditionalism",
         "hosts": "Pablo Peniche",
+        "rsvp": 21,
         "description": "Talk about architecture (buildings & computers) and the installation of the Aaron Swartz statue"
       },
       {
         "title": "Droning on (Ukraine Drone Discussion)",
         "hosts": "Nathan Young",
+        "rsvp": 34,
         "description": "Nathan presents rough notes for a piece he's writing about drones in Ukraine and then group discussion."
       },
       {
         "title": "Decision Markets Are Broken — How Do We Fix Them?",
         "hosts": "Drake Thomas",
+        "rsvp": 24,
         "description": "The standard way that decision markets are presented (eg in the futarchy paper) has some subtle flaws that make the incentives very screwy. We'll talk about what the problems are, and then go over some ways you might try to solve them. Lots of open-ended discussion encouraged - I have solutions that I like but there's room for even wackier approaches that might be better!"
       },
       {
         "title": "Experimental Meditation Experiments",
         "hosts": "Raj Thimmiah",
+        "rsvp": 6,
         "description": "I've had some good experiences doing meditation in experiment cycles of: do some reading come up with a meditation experiment try the experiment for a fixed amount of time reflect on the experiment repeat especially when I do this paired with friends. I'll try to provide some light framing for other people to try this with me - helps if you come to this with a friend (my goal with this session is for people to have fun coming up with experiments + to make more friends that like meditating)"
       },
       {
         "title": "Catholic Mass at Newman Parish",
         "hosts": "",
+        "rsvp": 9,
         "description": "We'll meet at the Lighthaven entrance at 9:45 and walk over to Newman Parish for 10am Catholic Mass! Join us, we'd love to have you whether you're religious or not~"
       },
       {
         "title": "Discussing Anthropic's Impact",
         "hosts": "Joe Rogero",
+        "rsvp": 37,
         "description": "Zac Hatfield-Dodds and Joe Rogero chat publicly and unofficially about the net impact of Anthropic. There will be some time for Q&A at the end."
       },
       {
         "title": "Poker Satellite #6",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 4
       },
       {
         "title": "Lunch",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 33
       },
       {
         "title": "Wave's Culture: a Debrief",
         "hosts": "Lincoln Quirk",
+        "rsvp": 22,
         "description": "Join Lincoln Quirk and Julia Carvalho as they run a postmortem on Wave's culture, a unicorn mobile-money startup and one of EA's biggest success stories. (This session will not be recorded.)"
       },
       {
         "title": "Panel: Has Trading & Gambling Gone Too Far in the US?",
         "hosts": "Jeremiah Johnson",
+        "rsvp": 46,
         "description": "Ft Jeremiah Johnson, Isaac Rose-Berman, Christopher Gerlacher"
       },
       {
         "title": "What We've Learned Doing Futarchy for a Year",
         "hosts": "Proph3t",
+        "rsvp": 33,
         "description": "I work on MetaDAO, the world’s biggest futarchy platform with 14 organizations, 69 decision markets, and $5.8m in assets under futarchy. Will be covering all that we’ve learned in the year of running futarchy in production and convincing organizations to adopt it."
       },
       {
         "title": "Manifest Destiny: Space Colonization Beyond Moon & Mars",
         "hosts": "Matt Parlmer",
+        "rsvp": 43,
         "description": "We're going back to the Moon, and there will likely soon be a colony on Mars, but there isn't much discourse about how we transition from exploring the solar system to exploiting it. Let's change that."
       },
       {
         "title": "Nate Soares & Emmett Shear Fight About AI",
         "hosts": "Nate Soares",
+        "rsvp": 124,
         "description": "A friendly conversation between Emmett Shear and Nate Soares about where their models of AI differ especially on the topic of Whether Humanity Should Stop Advancing AI Capabilities"
       },
       {
         "title": "AI Forecasting & Epistemics Projects I'd Like to See",
         "hosts": "Javier Prieto",
+        "rsvp": 36,
         "description": "Using LLMs to make our beliefs more accurate is possible and important and fun and we should be doing more of it. In this session, I will describe some projects the Open Philanthropy forecasting team would be excited to see. There will be Q&A at the end. There might also be some cheap demos I'll vibecode the night before."
       },
       {
         "title": "US Public Sector Demographics",
         "hosts": "Michael Lachanski",
+        "rsvp": 23,
         "description": "TBD"
       },
       {
         "title": "GLP-1 Discussion Group",
         "hosts": "Andrew Rettek",
+        "rsvp": 25,
         "description": "Enough of us are taking some form of GLP-1 drugs Let's get together to discuss our experience with them."
       },
       {
         "title": "How Could Deep Learning Work Well in the Real World?",
         "hosts": "Alex Gajewski",
+        "rsvp": 28,
         "description": "We will look to the history of deep learning to understand where it has worked well in the past, and discuss an approach to training robotics models by scaling real world data collection as far as it can go."
       },
       {
         "title": "AI for Adjudication",
         "hosts": "Campbell Hutcheson",
+        "rsvp": 24,
         "description": "Talking about what is necessary for an AI judge for legal matters, how it would best be first introduced, etc..."
       },
       {
         "title": "American Manufacturing War Room",
         "hosts": "Matt Parlmer",
+        "rsvp": 18,
         "description": "Brief group discussion for anybody interested in rapidly increasing American industrial capacity. Serious ideas around making more things domestically encouraged, gains-to-trade sealioning discouraged."
       },
       {
         "title": "The Furry Slayer",
         "hosts": "Tracing Woodgrains",
+        "rsvp": 51,
         "description": "A previously untold story about the peculiar connections between the founder of Reddit's largest \"anti-furry\" forum and a furry power moderator on the site, the major news stories they broke, the trouble they caused, and the friends they made along the way."
       },
       {
         "title": "Advanced Prediction Markets: Past, Present, Future",
         "hosts": "Robin Hanson",
+        "rsvp": 92,
         "description": "Ft Hanson, White, Santos, Liston"
       },
       {
         "title": "AI Evals on All the Things",
         "hosts": "Ozzie Gooen",
+        "rsvp": 42,
         "description": "\"Evaluation\" is arguably \"forecasting, but with extra steps.\" It might correspondingly make sense for people interested in forecasting infrastructure to consider also working on evaluation infrastructure. AIs are making certain evaluations incredibly cheap, so there seem to be new opportunities for projects in this space. In this talk we'll show one relevant web prototype and discuss the big-picture potential of the space."
       },
       {
         "title": "Controlling AI, with Redwood & UK AISI",
         "hosts": "Asa Cooper Stickland",
+        "rsvp": 22,
         "description": "Buck Shlegeris (from Redwood Research) and Asa Cooper Stickland (from the UK AI Security Institute) talk about AI Control, what should the portfolio of approaches to AI safety be (and what evidence would change this portfolio), at what capability level will we get misaligned AI, and maybe UK AISI/AI governance."
       },
       {
         "title": "Intro to Trading",
         "hosts": "Ricki Heicklen",
+        "rsvp": 71,
         "description": "Ricki Heicklen (and other instructors) will present the first hour-long class of quant trading bootcamp. Some people pay $88.09 per hour to attend content like this, but you can get it for free! Reply"
       },
       {
         "title": "Overton Window Engineering",
         "hosts": "John Bennett",
+        "rsvp": 24,
         "description": "What will happen when the Overton Window shatters? What can we do to better prepare for opportunities, events that surprise the policy community? Last week we discussed how to link policy proposals to political surprises, so that our policies are in the room when radical ideas are considered. This time we’ll discuss how to win those debates. Why does DC compress complicated policy proposals into a few words? What policy shorthand is more effective? What makes a memetically fit slogan? Are these Dark Arts? How should we feel about that? Note: This is a sequel to my session from LessOnline, but I’m not assuming any prior knowledge. Framed to still be useful for people who already caught Episode 1."
       },
       {
         "title": "Decentralized AI: Upsides, Risks & Tech Tree",
         "hosts": "Allison Duettmann",
+        "rsvp": 51,
         "description": "Decentralized AI: upsides, risks & tech tree"
       },
       {
         "title": "The First Quadrillion Is the Hardest",
         "hosts": "Flip Pidot",
+        "rsvp": 35,
         "description": "Prediction markets are on the brink of their fourth wave—a transformation from niche curiosity to global financial mainstay. From the early days of Intrade and PredictIt to today's breakout platforms like Manifold, Polymarket, and Kalshi, each wave has expanded the reach and relevance of event markets. Now, a convergence of factors—regulatory tailwinds, institutional interest, and breakthroughs in market microstructure—points toward a future where event futures sit alongside commodity derivatives as core tools for hedging policy risk and allocating capital. This talk explores what it will take for prediction markets to move from billions to quadrillions in annual volume, and what that means for investors, traders, policymakers, and builders looking to embrace, enjoy, and profit from this inevitable and imminent asymptotic moment."
       },
       {
         "title": "Public Speaking 101",
         "hosts": "Joe Rogero",
+        "rsvp": 20,
         "description": "Practice your public speaking skills! We'll go over a few takeaways from my time as an officer in a Toastmasters club, and we'll help you get over your stage fright with quick talks and immediate feedback."
       },
       {
         "title": "How to Build an Exchange",
         "hosts": "Rachel Wonnacott",
+        "rsvp": 64,
         "description": "Exploring techniques to build high throughput software systemsStock exchanges routinely process tens of thousands of messages per second, and are designed to process millions in case of high volatility. This isn’t particularly surprising in itself — Google handles approximately this many queries. What’s surprising is that stock exchanges can do this on a single server, whereas Google’s search engine runs on untold fleets of machines around the world. General topics: Building very high throughput systems in resource constrained environments Designing reliable architectures for low latency software systems How a stock exchange produces trades between traders' and investors' orders (order books, auctions, implied matching) Fairness implications: equal treatment of incoming orders, dissemination of market information to market participants and the public No trading or finance experience needed. Basic coding experience is required. Rachel Wonnacott was a core software engineer at a proprietary trading firm from 2019 to 2025. No tickets are required."
       },
       {
         "title": "Reversible Cryopreservation",
         "hosts": "Laura Deming",
+        "rsvp": 56,
         "description": "A pragmatic analysis of reversible cryopresevation and its technical feasibility."
       },
       {
         "title": "Writing & Slop: Roon, Scott Alexander, Gwern, Alexander Wales",
         "hosts": "Roon",
+        "rsvp": 112,
         "description": "Writing & slop w Roon, Scott Alexander, Gwern, and Alexander Wales. No recording or photos please. This talk will be very oversubscribed, don't expect to get in if you show up late. ps we moved this talk from rat park to C so we could be sure of the pocket of pseudonymity being maintained. thank you for understanding - rach"
       },
       {
         "title": "An Asian Perspective of Prediction Markets",
         "hosts": "Nancy Yi",
+        "rsvp": 24,
         "description": "Bayes, the Asia-based prediction market, will hold an office hour session sharing why Asia and Prediction Markets are a natural fit. Nancy from Bayes team will talk about why the team decides to build up a prediction market for Asia, and how the cultural context inspired us to design a long-tail APMM and other interesting product features. We are honored to invite Professor Mike Yao also to share with us his research about how people from different culture perceive truth differently. Mike Yao is the Professor of Digital Media, Director of the Institute of Communications Research at UIUC. His research focuses on the social and psychological impacts of interactive digital media. The Bayes team will also be there to answer any questions regarding technical details and social with everyone."
       },
       {
         "title": "London Meetup",
         "hosts": "Sam",
+        "rsvp": 7,
         "description": "Meet people from the Imperial Capital. 🏴󠁧󠁢󠁥󠁮󠁧󠁿 Honi soit qui mal y pense!"
       },
       {
         "title": "Men's Fashion Advice",
-        "hosts": "Rachel Weinberg"
+        "hosts": "Rachel Weinberg",
+        "rsvp": 27
       },
       {
         "title": "Overcoming Sexual Shame",
         "hosts": "Jehan Azad",
+        "rsvp": 9,
         "description": "At How to be Hot (with Aella), a bunch of people had difficulty expressing sexual attraction, but I was shameless! I'd like to try and help people have less shame. We'll do some exercises, maybe with hot girls."
       },
       {
         "title": "Simple Improv Games",
         "hosts": "Simon Baars",
+        "rsvp": 15,
         "description": "We'll play a couple of simple warmup improv games: either word games or simple comedy games. Great for those new at improv."
       },
       {
         "title": "Women Who Wouldn't Be Caught Dead at a 'Women In...' Event",
         "hosts": "Jennifer Chen",
+        "rsvp": 15,
         "description": "to start - so how’s your relationship with your mother?"
       },
       {
         "title": "Kalshi's Great Bean Content Reveal",
         "hosts": "Noah Sternig",
+        "rsvp": 19,
         "description": "A simple game with a prediction market twist. Join us as we reveal Manifest's top bean counter(s)."
       },
       {
         "title": "A History of Predictive Processing from Democritus",
         "hosts": "Emmett Shear",
+        "rsvp": 85,
         "description": "I will lead a live demonstration of the \"Somers System\" of land valuation in which a moderator gathers together a group of people and gets them to collectively value land in their local jurisdiction. I'll need either a laptop and projector, or else just a big paper map on the wall. I'll start by asking \"What's the most valuable stretch of street in Berkeley?\" Someone will give an answer. I'll write down 100 right there. Then I'll say, \"What's the NEXT most valuable stretch of street in Berkeley?\" Someone else will give an answer. I'll ask, \"How much is it worth, RELATIVE to Berkeley?\" They'll give some number, say 95%. I'll write down 95. And so on until we've filled up the whole thing. Then I'll explain how the historical Georgist movement relied on a method just like this to value land. It was used in lots big American cities for decades, including Cleveland, Colombus, Baltimore, Houston, and even New York City. Will it work? Who knows! The purpose of this demonstration is to test it out with a real audience. People should bet on the outcome in advance! See also: How Georgists Valued Land in the 1900s"
       },
       {
         "title": "Prediction, Personalization, Participation: the Bayes Bandit",
         "hosts": "Jacky Chu",
+        "rsvp": 11,
         "description": "Since the launch of Bayes’ beta version, we’re excited to unveil our “TikTok Moment” for the prediction market. Dive in and explore our recommendation systems, the APMM mechanism, and start crafting your own questions today!Feel free to check it out at beta.bayes.market!"
       },
       {
         "title": "The Case for Interactionist Dualism",
         "hosts": "Vivienne Bellerose",
+        "rsvp": 24,
         "description": "Artificial intelligence and the specter of transhumanism make pressing the need for a coherent theory of consciousness. I explain why the alternative theories of analytic materialism, non-analytic materialism, property dualism, and panpsychism are flawed, leaving interactionist dualism — the theory that \"mental stuff\" is distinct from physical matter as we know it and the two undergo two-way causal interaction — as the best alternative. I will move quickly, so a basic familiarity with philosophy of mind is recommended, but it shouldn't be required."
       },
       {
         "title": "Poetry Art Jam Renga Party",
         "hosts": "Malcolm Jackson",
+        "rsvp": 5,
         "description": "Come thru to write some collaborative poetry based on renga/haiku! We can follow some established rules, make our own, use visual art, etc And if folks are game, for the last 15ish mins, we can have a freestyle rap session after we're done with our piece"
       },
       {
         "title": "Similarities Between Selling to Nation States and on Facebook Marketplace",
         "hosts": "Jimmy Hsu",
+        "rsvp": 7,
         "description": "The process of selling on FB Marketplace and to a Nation State is closer than they appear. Learn how the process works, and pick up a thing or two about negotiating. Format is more a discussion and less a presentation."
       },
       {
         "title": "AI Will Not Be Conscious (Blindsight Hypothesis)",
         "hosts": "Brett aka Tumbles",
+        "rsvp": 19,
         "description": "Could AI become conscious as capabilities increase? There is a model of consciousness as an idiosyncratic, vibes-based construct for managing motivation and problem solving. Messy, as many of natural selection’s creations are. There are more effective and more obvious methods of managing an agent, and engineers will arrive at those solutions long before reinventing consciousness. Will be lots of time for questions and comments."
       },
       {
         "title": "Prediction Market Parlays",
         "hosts": "Benjamin Scheinberg",
+        "rsvp": 11,
         "description": "Parlays make up 30% of US sportsbetting volume and around 50% of the revenue. Let's have a discussion about how we could implement them on prediction markets."
       },
       {
         "title": "Poker Satellite #7",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 5
       },
       {
         "title": "Closing Ceremony",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 65
       },
       {
         "title": "Dinner (Starts 5:30)",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 24
       },
       {
         "title": "Big Manifold Awards Ceremony",
         "hosts": "Ian Philips",
+        "rsvp": 37,
         "description": "Manifold presents: The Manny awards! It's what you've been working for so hard all year: judges from the staff and community put their heads together to help determine the winningest community members in several categories. Top nominees in categories such as Best Market, Best Debtor, Best Commenter, Funniest Market, Best Bot, etc. compete head-to-head in a LIVE marble race. Votes award extra entries in the marble race and the winners win BIG. https://manifold.markets/topic/big-manifest-awards-ceremony"
       },
       {
         "title": "Reserved",
-        "hosts": "John Bennett"
+        "hosts": "John Bennett",
+        "rsvp": 3
       },
       {
         "title": "Tech, Policy, and the Future of Private Equity",
         "hosts": "Alex Aridgides",
+        "rsvp": 3,
         "description": "Zero-commission trading, fractional shares, and diversified ETFs changed how the masses invest—but much of global capital still sits in opaque private equity deals. As AI valuations increase and secondaries slowly become more popular, old rules still exist: accreditation, holder caps, liquidity locks, and valuation opacity. I’ll map the macro, tech, legal landscapes that will shape PE over the next five years, and then discuss which innovations might finally crack the access code."
       },
       {
         "title": "Good Cities",
         "hosts": "Theo Jaffee",
+        "rsvp": 15,
         "description": "Discussing the principles of good urbanism"
       },
       {
         "title": "Robot Meetup",
         "hosts": "Tessa Barton",
+        "rsvp": 14,
         "description": "We will discuss robots, robot supply chains, robot capabilities"
       },
       {
         "title": "Fun Etymology",
         "hosts": "Alok Singh",
+        "rsvp": 4,
         "description": "Alok talks on more ety"
       },
       {
         "title": "Poker Final Table",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 14
       },
       {
         "title": "Rock Paper Scissors Poker",
         "hosts": "chris (strutheo)",
+        "rsvp": 1,
         "description": "Custom variant invented last manifest by us!"
       },
       {
         "title": "Late Night Hangouts / Dance Party / Other Closing Socials",
-        "hosts": "David Chee"
+        "hosts": "David Chee",
+        "rsvp": 53
       }
     ]
   }

--- a/public/pastsessions/events.json
+++ b/public/pastsessions/events.json
@@ -5,7 +5,7 @@
       {
         "color": "rose",
         "title": "Manifold Theater: Sweepstakes Mania (feat. Duncan Horst of Bet on Love)",
-        "hosts": "Duncan Horst, Tim Blais",
+        "hosts": "Tim Blais & Duncan Horst",
         "rsvp": 60,
         "venue": "Rat Park",
         "start": "4:30 PM",
@@ -35,7 +35,7 @@
       {
         "color": "orange",
         "title": "Fireside Chat with Founder of Upstart, Paul Gu",
-        "hosts": "Paul Gu, Austin Chen",
+        "hosts": "Paul Gu & Austin Chen",
         "rsvp": 21,
         "venue": "Eigen Hall",
         "start": "4:30 PM",
@@ -54,7 +54,7 @@
       {
         "color": "orange",
         "title": "The Politics of Election Market Bans",
-        "hosts": "Jeremiah Johnson, Maxim Lott, Peter Hammon",
+        "hosts": "Jeremiah Johnson & Maxim Lott & Peter Hammon",
         "rsvp": 68,
         "venue": "Eigen Hall",
         "start": "7:00 PM",
@@ -154,7 +154,7 @@
       {
         "color": "lime",
         "title": "Theo Jaffee Interviews Stephen Grugett",
-        "hosts": "Stephen Grugett, Theodore Jaffee",
+        "hosts": "Stephen Grugett & Theodore Jaffee",
         "rsvp": 34,
         "venue": "Bayes Attic",
         "start": "8:00 PM",
@@ -407,7 +407,7 @@
       {
         "color": "rose",
         "title": "Why So Much Disagreement About AI Risk?",
-        "hosts": "Josh Rosenberg, Scott Alexander, Misha Glouberman",
+        "hosts": "Josh Rosenberg & Scott Alexander & Misha Glouberman",
         "rsvp": 131,
         "venue": "Rat Park",
         "start": "1:00 PM",
@@ -417,7 +417,7 @@
       {
         "color": "rose",
         "title": "Fireside Chat with Substack CEO, Chris Best",
-        "hosts": "Chris Best, Austin Chen",
+        "hosts": "Chris Best & Austin Chen",
         "rsvp": 104,
         "venue": "Rat Park",
         "start": "2:00 PM",
@@ -464,7 +464,7 @@
       {
         "color": "orange",
         "title": "Metaculus: $120K AI Benchmarking Tournament Announcement & Build-A-Bot Workshop",
-        "hosts": "Deger Turan, Tom Liptay",
+        "hosts": "Tom Liptay & Deger Turan",
         "rsvp": 48,
         "venue": "Eigen Hall",
         "start": "11:00 AM",
@@ -483,7 +483,7 @@
       {
         "color": "orange",
         "title": "Hard Questions for Manifold",
-        "hosts": "Stephen Grugett, James Grugett, Austin Chen",
+        "hosts": "Austin Chen, James Grugett & Stephen Grugett",
         "rsvp": 56,
         "venue": "Eigen Hall",
         "start": "1:00 PM",
@@ -773,7 +773,7 @@
       {
         "color": "green",
         "title": "Founders Meetup",
-        "hosts": "Jonathan Miller, Yingru Qiu",
+        "hosts": "Yingru Qiu & Jonathan Miller",
         "rsvp": 24,
         "venue": "Gyroscope",
         "start": "10:00 AM",
@@ -783,7 +783,7 @@
       {
         "color": "green",
         "title": "Events Should Be Good, Not Bad",
-        "hosts": "Austin Chen, Misha Glouberman",
+        "hosts": "Austin Chen & Misha Glouberman",
         "rsvp": 48,
         "venue": "Gyroscope",
         "start": "11:00 AM",
@@ -813,7 +813,7 @@
       {
         "color": "green",
         "title": "Futarchy and Conditional Markets",
-        "hosts": "Kelvin Santos, Robin Hanson, Austin Chen",
+        "hosts": "Austin Chen, Robin Hanson & Kelvin Santos",
         "rsvp": 58,
         "venue": "Gyroscope",
         "start": "3:00 PM",
@@ -1055,7 +1055,7 @@
       },
       {
         "title": "Emergent gameplay and narrative",
-        "hosts": "Patrick McKenzie, Justin Kuiper",
+        "hosts": "Justin Kuiper & Patrick McKenzie",
         "rsvp": 51,
         "venue": "Gyroscope",
         "start": "1:00 PM",
@@ -1064,7 +1064,7 @@
       },
       {
         "title": "Banking + Dragons: analyzing The Dagger and the Coin",
-        "hosts": "Patrick McKenzie, Justin Kuiper",
+        "hosts": "Justin Kuiper & Patrick McKenzie",
         "rsvp": 31,
         "venue": "Gyroscope",
         "start": "1:30 PM",
@@ -1240,7 +1240,7 @@
       },
       {
         "title": "Draw Bluey",
-        "hosts": "keltan O’Shea, Isabella Jones, Isaac Henry Linn, August Veix",
+        "hosts": "August Veix & keltan O’Shea & Isabella Jones & Isaac Henry Linn",
         "rsvp": 7,
         "venue": "Bayes Ground",
         "start": "11:00 PM",
@@ -1294,7 +1294,7 @@
       {
         "color": "rose",
         "title": "Behind the Numbers: Eliciting Rationales to Improve Decision-Making",
-        "hosts": "Cate Hall, Dan Schwarz, Josh Rosenberg, Deger Turan",
+        "hosts": "Cate Hall & Dan Schwarz & Deger Turan & Josh Rosenberg",
         "rsvp": 61,
         "venue": "Rat Park",
         "start": "1:00 PM",
@@ -1747,7 +1747,7 @@
       },
       {
         "title": "Starting a Microschool: An interview with Kelsey Piper and June Kreml",
-        "hosts": "Jasmine Ren, Kelsey Piper, June Kreml",
+        "hosts": "June Kreml & Jasmine Ren & Kelsey Piper",
         "rsvp": 85,
         "venue": "Eigen Hall",
         "start": "9:30 AM",
@@ -1993,7 +1993,7 @@
       },
       {
         "title": "<in the rat park dome> Church",
-        "hosts": "Lydia La Roux, Ian Phillips, Robin Hanson, Sy Etirabys",
+        "hosts": "Sy Etirabys & Ian Phillips & Robin Hanson & Lydia La Roux",
         "rsvp": 9,
         "venue": "Bayes Attic",
         "start": "8:00 PM",

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -149,18 +149,22 @@
   .session {
     background: var(--card);
     border: 1px solid var(--rule);
-    padding: 10px 12px;
+    padding: 8px 10px;
     border-radius: 6px;
     transition: transform 100ms;
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(96px, 38%);
-    grid-template-rows: auto 1fr;
-    gap: 2px 12px;
-    min-height: 86px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
     break-inside: avoid;
-    margin: 0 0 10px;
+    margin: 0 0 8px;
   }
   .session:hover { transform: translateY(-1px); }
+  .session__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+  }
   #session-tooltip {
     position: fixed;
     display: none;
@@ -209,16 +213,14 @@
     font-weight: 600;
     color: #5d5547;
     opacity: 0.7;
-    margin-bottom: 6px;
-    grid-column: 1;
-    grid-row: 1;
-    align-self: start;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .session .rsvp {
-    grid-column: 2;
-    grid-row: 1;
-    justify-self: end;
-    align-self: start;
+    flex: 0 0 auto;
     display: inline-flex;
     align-items: center;
     gap: 4px;
@@ -239,22 +241,24 @@
   .session .title {
     font-size: 12px;
     font-weight: 700;
-    margin-bottom: 0;
     color: #2b2419;
     line-height: 1.28;
-    grid-column: 1;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
   .session .speaker {
     font-family: var(--font-cinzel);
     font-size: 12px;
     color: #5d5547;
     font-style: italic;
-    grid-column: 2;
-    grid-row: 2;
-    justify-self: end;
-    align-self: end;
     text-align: right;
+    align-self: stretch;
     overflow-wrap: break-word;
+    line-height: 1.25;
+    margin-top: 3px;
   }
   .session .speaker-name { display: inline-block; white-space: nowrap; }
   .session a.speaker-name { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
@@ -286,13 +290,6 @@
     header.site h1 { font-size: 28px; }
     h2.day { font-size: 22px; }
     .session-grid { column-count: 1; }
-    .session { grid-template-columns: minmax(0, 1fr); }
-    .session .speaker {
-      grid-column: 1;
-      grid-row: auto;
-      justify-self: start;
-      text-align: left;
-    }
   }
 </style>
 </head>
@@ -460,6 +457,7 @@ const CATEGORY_OVERRIDES = {
   'awkwardmaxxing for the socially anxious': 'workshop',
   'balance games and wrestling!': 'game',
   'banterbrush: chill, chat and make art': 'social',
+  'behind the numbers: eliciting rationales to improve decision-making': 'panel',
   'big manifold awards ceremony': 'performance',
   'breaking the blank slate: social consequences of genetic screening': 'talk',
   'build the future of universities with me': 'workshop',
@@ -476,6 +474,7 @@ const CATEGORY_OVERRIDES = {
   'draw bluey': 'social',
   'epic math puzzle sesh': 'game',
   'experimental conversational format': 'social',
+  'emergent gameplay and narrative': 'panel',
   'figgie': 'game',
   'fine-tuning, the multiverse, anthropic bias, and the reference-class problem': 'panel',
   'fire 101 & hidden traps': 'talk',
@@ -599,13 +598,15 @@ function createSessionCard(session) {
   const cat = categorize(session.title, session.speaker);
   card.dataset.cat = cat;
   card.innerHTML = `
-    <div class="cat-label"></div>
-    <div class="rsvp">
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <circle cx="12" cy="8" r="4"/>
-        <path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/>
-      </svg>
-      <span class="rsvp-count"></span>
+    <div class="session__top">
+      <div class="cat-label"></div>
+      <div class="rsvp">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="8" r="4"/>
+          <path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"/>
+        </svg>
+        <span class="rsvp-count"></span>
+      </div>
     </div>
     <div class="title"></div>
     <div class="speaker"></div>`;
@@ -630,20 +631,34 @@ function createSessionCard(session) {
     card.tabIndex = 0;
   }
   const speakerEl = card.querySelector('.speaker');
-  const names = (session.speaker || '').split(',').map(s => s.trim()).filter(Boolean);
+  let groups = (session.speaker || '').split(',').map(s => s.trim()).filter(Boolean);
+  groups.sort((a, b) => a.length - b.length);
+  if (groups.length === 2 && !groups[0].includes('&') && !groups[1].includes('&')) {
+    groups = [groups.join(' & ')];
+  }
   speakerEl.textContent = '';
-  names.forEach((name, i) => {
-    const url = SPEAKER_LINKS[name];
-    const el = document.createElement(url ? 'a' : 'span');
-    el.className = 'speaker-name';
-    el.textContent = name;
-    if (url) {
-      el.href = url;
-      el.target = '_blank';
-      el.rel = 'noopener noreferrer';
-    }
-    speakerEl.appendChild(el);
-    if (i < names.length - 1) speakerEl.appendChild(document.createElement('br'));
+  groups.forEach((group, gi) => {
+    const subnames = group.split(/\s*&\s*/).map(s => s.trim()).filter(Boolean).sort((a, b) => a.length - b.length);
+    subnames.forEach((name, si) => {
+      if (si > 0) {
+        let sep;
+        if (subnames.length === 2) sep = ' & ';
+        else if (si === subnames.length - 1) sep = ', & ';
+        else sep = ', ';
+        speakerEl.appendChild(document.createTextNode(sep));
+      }
+      const url = SPEAKER_LINKS[name];
+      const el = document.createElement(url ? 'a' : 'span');
+      el.className = 'speaker-name';
+      el.textContent = name;
+      if (url) {
+        el.href = url;
+        el.target = '_blank';
+        el.rel = 'noopener noreferrer';
+      }
+      speakerEl.appendChild(el);
+    });
+    if (gi < groups.length - 1) speakerEl.appendChild(document.createElement('br'));
   });
   return { card, cat };
 }

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -149,17 +149,16 @@
   .session {
     background: var(--card);
     border: 1px solid var(--rule);
-    padding: 16px;
+    padding: 10px 12px;
     border-radius: 6px;
     transition: transform 100ms;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-rows: auto 1fr auto;
-    column-gap: 12px;
-    row-gap: 12px;
-    min-height: 132px;
+    grid-template-columns: minmax(0, 1fr) minmax(96px, 38%);
+    grid-template-rows: auto 1fr;
+    gap: 2px 12px;
+    min-height: 86px;
     break-inside: avoid;
-    margin: 0 0 12px;
+    margin: 0 0 10px;
   }
   .session:hover { transform: translateY(-1px); }
   #session-tooltip {
@@ -210,19 +209,16 @@
     font-weight: 600;
     color: #5d5547;
     opacity: 0.7;
+    margin-bottom: 6px;
     grid-column: 1;
     grid-row: 1;
-    align-self: center;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    align-self: start;
   }
   .session .rsvp {
     grid-column: 2;
     grid-row: 1;
     justify-self: end;
-    align-self: center;
+    align-self: start;
     display: inline-flex;
     align-items: center;
     gap: 4px;
@@ -243,27 +239,22 @@
   .session .title {
     font-size: 12px;
     font-weight: 700;
+    margin-bottom: 0;
     color: #2b2419;
     line-height: 1.28;
-    grid-column: 1 / -1;
-    grid-row: 2;
-    margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    min-height: calc(12px * 1.28 * 3);
+    grid-column: 1;
   }
   .session .speaker {
     font-family: var(--font-cinzel);
     font-size: 12px;
     color: #5d5547;
     font-style: italic;
-    grid-column: 1 / -1;
-    grid-row: 3;
-    text-align: left;
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: end;
+    align-self: end;
+    text-align: right;
     overflow-wrap: break-word;
-    line-height: 1.35;
   }
   .session .speaker-name { display: inline-block; white-space: nowrap; }
   .session a.speaker-name { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
@@ -295,6 +286,13 @@
     header.site h1 { font-size: 28px; }
     h2.day { font-size: 22px; }
     .session-grid { column-count: 1; }
+    .session { grid-template-columns: minmax(0, 1fr); }
+    .session .speaker {
+      grid-column: 1;
+      grid-row: auto;
+      justify-self: start;
+      text-align: left;
+    }
   }
 </style>
 </head>

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -80,7 +80,6 @@
     font-weight: 700;
   }
 
-  footer.site #year-meta::before { content: " · "; }
   footer.site #year-organizers { margin-top: 4px; }
 
   .filter-row {
@@ -283,13 +282,30 @@
     border-top: 1px solid var(--rule);
     font-size: 12px;
     color: var(--muted);
-    text-align: center;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: end;
+    gap: 12px;
+  }
+  footer.site .footer-left { grid-column: 1; text-align: left; }
+  footer.site .footer-center { grid-column: 2; text-align: center; }
+  footer.site .footer-right {
+    grid-column: 3;
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
   }
   @media (max-width: 600px) {
     .wrap { padding: 24px 16px 60px; }
     header.site h1 { font-size: 28px; }
     h2.day { font-size: 22px; }
     .session-grid { column-count: 1; }
+    footer.site { grid-template-columns: 1fr; }
+    footer.site .footer-left,
+    footer.site .footer-center,
+    footer.site .footer-right { grid-column: 1; text-align: center; align-items: center; }
   }
 </style>
 </head>
@@ -317,9 +333,12 @@
   <div id="session-tooltip" role="tooltip"></div>
 
   <footer class="site">
-    <span id="footer-text"></span>
-    <span id="year-meta"></span>
-    <div id="year-organizers"></div>
+    <div class="footer-left"><span id="year-meta"></span></div>
+    <div class="footer-center"><div id="year-organizers"></div></div>
+    <div class="footer-right">
+      <div id="footer-text"></div>
+      <div id="year-vods"></div>
+    </div>
   </footer>
 </div>
 
@@ -327,9 +346,9 @@
 const slugify = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
 const META = {
-  '2025': { dates: 'June 6–8, 2025', organizers: 'David Chee, Rachel Farley & Austin Chen' },
-  '2024': { dates: 'June 7–9, 2024', organizers: 'Saul Munn, Rachel Weinberg & Austin Chen' },
-  '2023': { dates: 'September 22–24, 2023', organizers: 'Saul Munn, David Chee & Austin Chen' },
+  '2025': { dates: 'June 6–8, 2025', organizers: 'David Chee, Rachel Farley & Austin Chen', url: 'https://manifest.is/2025' },
+  '2024': { dates: 'June 7–9, 2024', organizers: 'Saul Munn, Rachel Weinberg & Austin Chen', vods: 'https://www.youtube.com/playlist?list=PL1CkJbX2uY1oUCObygB3mKg1YRACYbIQZ' },
+  '2023': { dates: 'September 22–24, 2023', organizers: 'Saul Munn, David Chee & Austin Chen', vods: 'https://www.youtube.com/playlist?list=PL1CkJbX2uY1rtuVJmN4TIjRy7ZFPOdAQV' },
 };
 
 const YEAR_FILES = {
@@ -535,6 +554,13 @@ const CATEGORY_OVERRIDES = {
 };
 
 const SPEAKER_LINKS = {};
+const ORGANIZER_LINKS = {
+  'Austin Chen': 'https://www.linkedin.com/in/austinch/',
+  'Rachel Weinberg': 'https://www.linkedin.com/in/rachel-weinberg-789b23228/',
+  'Saul Munn': 'https://saulmunn.com',
+  'Rachel Farley': 'https://www.linkedin.com/in/rachelmfarley/',
+  'David Chee': 'https://www.linkedin.com/in/david-chee-355a551a0',
+};
 const tooltipEl = document.getElementById('session-tooltip');
 
 function categorize(title, hosts) {
@@ -727,11 +753,23 @@ async function loadYear(year) {
 
   // Year meta
   document.getElementById('year-meta').textContent = meta.dates;
-  document.getElementById('footer-text').textContent = `Manifest ${year}`;
+  const footerEl = document.getElementById('footer-text');
+  footerEl.textContent = '';
+  const label = `Manifest ${year}`;
+  if (meta.url) {
+    const a = document.createElement('a');
+    a.href = meta.url;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.textContent = label;
+    footerEl.appendChild(a);
+  } else {
+    footerEl.textContent = label;
+  }
   const orgEl = document.getElementById('year-organizers');
   orgEl.textContent = '';
   meta.organizers.split(/\s*[,&]\s*/).forEach((name, i, arr) => {
-    const url = SPEAKER_LINKS[name];
+    const url = ORGANIZER_LINKS[name];
     const el = document.createElement(url ? 'a' : 'span');
     el.textContent = name;
     if (url) {
@@ -742,6 +780,17 @@ async function loadYear(year) {
     orgEl.appendChild(el);
     if (i < arr.length - 1) orgEl.appendChild(document.createElement('br'));
   });
+
+  const vodsEl = document.getElementById('year-vods');
+  vodsEl.textContent = '';
+  if (meta.vods) {
+    const link = document.createElement('a');
+    link.href = meta.vods;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'Selected VODs';
+    vodsEl.appendChild(link);
+  }
 
   // Render schedule
   const catOrder = Object.fromEntries(CATEGORIES.map((c, i) => [c.key, i]));


### PR DESCRIPTION
## Summary
- Restructure past-session footer into a 3-column grid: date (bottom-left), organizers (bottom-center), `Manifest YYYY` + `Selected VODs` (bottom-right). Collapses to a single centered column on small screens.
- `Manifest 2025` in the footer now links to https://manifest.is/2025; `Selected VODs` links added for 2024 and 2023 YouTube playlists.
- Organizer names (Austin Chen, Saul Munn, Rachel Weinberg, Rachel Farley, David Chee) link only in the footer via a new `ORGANIZER_LINKS` map. `SPEAKER_LINKS` is now empty so no host names link inside session cards.
- Restore RSVP counts for all 69 Sunday 2025 sessions from the `manifest-2025-sessions.json` reference, including 15 that needed manual title-matching for punctuation/wording differences.

## Test plan
- [ ] Load `/pastsessions/`, switch between 2025 / 2024 / 2023 - footer shows date on left, organizers in center, Manifest YYYY (+ VODs link where applicable) on right
- [ ] Click `Manifest 2025` -> opens https://manifest.is/2025; click each `Selected VODs` -> opens correct YouTube playlist
- [ ] Organizer names in the footer are clickable; the same names appearing inside session cards are NOT links
- [ ] All Sunday 2025 cards show a 👤 RSVP count
- [ ] Resize to mobile width - footer columns stack and remain centered
