### PR TITLE
Update 2023 archive to 2023-10-01 snapshot + add password gate

### DIFF
--- a/public/2023/contact.html
+++ b/public/2023/contact.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US"  >
-  <head>
+  <head><!-- m23-gate --><script>(function(){try{if(sessionStorage.getItem('m23_ok')==='1')return;}catch(e){}
+document.documentElement.style.visibility='hidden';
+function show(){
+  document.documentElement.style.visibility='';
+  var d=document.createElement('div');
+  d.id='m23-gate';
+  d.style.cssText='position:fixed;inset:0;z-index:2147483647;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;';
+  d.innerHTML='<form id="m23-form" style="background:#1c1c1c;padding:32px 36px;border-radius:8px;width:340px;max-width:90vw;text-align:center;border:1px solid #333"><h2 style="margin:0 0 8px;font-size:22px;font-weight:600">Manifest 2023</h2><p style="margin:0 0 18px;color:#aaa;font-size:14px">Enter password to view archive</p><input id="m23-pw" type="password" autocomplete="off" autofocus style="width:100%;padding:10px 12px;font-size:16px;background:#111;color:#fff;border:1px solid #444;border-radius:6px;box-sizing:border-box"/><div id="m23-err" style="color:#ff6b6b;font-size:13px;height:18px;margin-top:8px"></div><button type="submit" style="margin-top:10px;width:100%;padding:10px;font-size:15px;background:#fff;color:#111;border:0;border-radius:6px;cursor:pointer;font-weight:600">Enter</button></form>';
+  document.body.appendChild(d);
+  document.getElementById('m23-form').addEventListener('submit',function(e){
+    e.preventDefault();
+    var v=document.getElementById('m23-pw').value;
+    if(v==='2023'){try{sessionStorage.setItem('m23_ok','1');}catch(e){}d.parentNode.removeChild(d);}
+    else{document.getElementById('m23-err').textContent='Incorrect password';}
+  });
+}
+if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
+})();</script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->
@@ -2462,7 +2479,7 @@
 </div></div></div><div class="fe-block fe-block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine</p>
+  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine, Misha Glouberman,<br>Wei Deng, Bo Lu</p>
 </div>
 
 

--- a/public/2023/index.html
+++ b/public/2023/index.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US"  >
-  <head>
+  <head><!-- m23-gate --><script>(function(){try{if(sessionStorage.getItem('m23_ok')==='1')return;}catch(e){}
+document.documentElement.style.visibility='hidden';
+function show(){
+  document.documentElement.style.visibility='';
+  var d=document.createElement('div');
+  d.id='m23-gate';
+  d.style.cssText='position:fixed;inset:0;z-index:2147483647;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;';
+  d.innerHTML='<form id="m23-form" style="background:#1c1c1c;padding:32px 36px;border-radius:8px;width:340px;max-width:90vw;text-align:center;border:1px solid #333"><h2 style="margin:0 0 8px;font-size:22px;font-weight:600">Manifest 2023</h2><p style="margin:0 0 18px;color:#aaa;font-size:14px">Enter password to view archive</p><input id="m23-pw" type="password" autocomplete="off" autofocus style="width:100%;padding:10px 12px;font-size:16px;background:#111;color:#fff;border:1px solid #444;border-radius:6px;box-sizing:border-box"/><div id="m23-err" style="color:#ff6b6b;font-size:13px;height:18px;margin-top:8px"></div><button type="submit" style="margin-top:10px;width:100%;padding:10px;font-size:15px;background:#fff;color:#111;border:0;border-radius:6px;cursor:pointer;font-weight:600">Enter</button></form>';
+  document.body.appendChild(d);
+  document.getElementById('m23-form').addEventListener('submit',function(e){
+    e.preventDefault();
+    var v=document.getElementById('m23-pw').value;
+    if(v==='2023'){try{sessionStorage.setItem('m23_ok','1');}catch(e){}d.parentNode.removeChild(d);}
+    else{document.getElementById('m23-err').textContent='Incorrect password';}
+  });
+}
+if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
+})();</script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->
@@ -1618,7 +1635,7 @@
 </style><div class="fluid-engine fe-64971299cf694f2700c3ed86"><div class="fe-block fe-block-yui_3_17_2_1_1687582093047_76534"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1687582093047_76534"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <h3 style="white-space:pre-wrap;">A gathering of forecasting nerds.</h3><p class="sqsrte-large" style="white-space:pre-wrap;">Meet friends, learn from <a href="/2023/speakers">experts</a>, play games &amp; chill at our lovely inn. And predict the future, ofc.</p><p class="sqsrte-large" style="white-space:pre-wrap;">Wondering what else to expect? <a href="https://manifold.markets/ManifestConference/suggest-some-sessions-for-manifest?r=TWFuaWZlc3RDb25mZXJlbmNl" target="_blank">Suggest a session</a> and earn mana if we do it!</p>
+  <h3 style="white-space:pre-wrap;">A gathering of forecasting nerds</h3><p class="sqsrte-large" style="white-space:pre-wrap;">Meet friends, learn from <a href="/2023/speakers">experts</a>, play games &amp; chill at our lovely campus. And predict the future, ofc.</p><p class="sqsrte-large" style="white-space:pre-wrap;">Wondering what else to expect? <a href="https://manifold.markets/ManifestConference/suggest-some-sessions-for-manifest?r=TWFuaWZlc3RDb25mZXJlbmNl" target="_blank">Suggest a session</a> and earn mana if we do it!</p>
 </div>
 
 
@@ -4161,7 +4178,7 @@
 </div></div></div><div class="fe-block fe-block-yui_3_17_2_1_1692404805542_31962"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1692404805542_31962"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <h3 style="white-space:pre-wrap;">Who</h3><p class="" style="white-space:pre-wrap;">Special guests include Robin Hanson, Nate Silver, Tarek Mansour, Patrick McKenzie, Shayne Coplan, Zvi Mowshowitz, Destiny, Dylan Matthews, Aella, and <a href="/2023/speakers">more</a>.</p><p class="" style="white-space:pre-wrap;">The average attendee is an economist, a stats student, a superforecaster, an existential risk researcher, a stock trader, etc. Maybe you, too — <a href="/2023/tickets">get your tickets now</a>!</p><h3 style="white-space:pre-wrap;">When</h3><p class="" style="white-space:pre-wrap;">September 22-24, 2023. Friday afternoon through Sunday night; see the <a href="/2023/schedule">schedule</a> for more info.</p><h3 style="white-space:pre-wrap;">Where</h3><p class="" style="white-space:pre-wrap;">The Rose Garden Inn — see pictures below.</p><p class="" style="white-space:pre-wrap;">2740 Telegraph Ave, Berkeley (94705), California, Earth (C-137). Aliens welcome.</p>
+  <h3 style="white-space:pre-wrap;">Who</h3><p class="" style="white-space:pre-wrap;">Special guests include Robin Hanson, Nate Silver, Tarek Mansour, Patrick McKenzie, Shayne Coplan, Zvi Mowshowitz, Destiny, Dylan Matthews, Aella, and <a href="/2023/speakers">more</a>.</p><p class="" style="white-space:pre-wrap;">The average attendee is an economist, a stats student, a superforecaster, an existential risk researcher, a stock trader, etc. Maybe you, too — <a href="/2023/tickets">get your tickets now</a>!</p><h3 style="white-space:pre-wrap;">When</h3><p class="" style="white-space:pre-wrap;">September 22-24, 2023. Friday afternoon through Sunday night; see the <a href="/2023/schedule">schedule</a> for more info.</p><h3 style="white-space:pre-wrap;">Where</h3><p class="" style="white-space:pre-wrap;">The Lighthaven campus.</p><p class="" style="white-space:pre-wrap;">2740 Telegraph Ave, Berkeley (94705), California, Earth (C-137). Aliens welcome.</p>
 </div>
 
 
@@ -4364,7 +4381,7 @@
       style= "padding-bottom: 40px;"
       data-section-title-alignment="center"
     >
-      <p class="" style="white-space:pre-wrap;">Hosted at the beautiful Rose Garden Inn.</p>
+      <p class="" style="white-space:pre-wrap;">The lovely Lighthaven campus</p>
     </div>
   
 
@@ -5170,7 +5187,7 @@
 },
 &quot;layout&quot;: &quot;carousel&quot;,
 &quot;isSectionTitleEnabled&quot;: true,
-&quot;sectionTitle&quot;: &quot;&lt;p class=\&quot;\&quot; style=\&quot;white-space:pre-wrap;\&quot;&gt;Hosted at the beautiful Rose Garden Inn.&lt;\/p&gt;&quot;,
+&quot;sectionTitle&quot;: &quot;&lt;p class=\&quot;\&quot; style=\&quot;white-space:pre-wrap;\&quot;&gt;The lovely Lighthaven campus&lt;\/p&gt;&quot;,
 &quot;spaceBelowSectionTitle&quot;: {
 &quot;value&quot;: 40,
 &quot;unit&quot;: &quot;px&quot;
@@ -7110,7 +7127,7 @@
 </div></div></div><div class="fe-block fe-block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine</p>
+  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine, Misha Glouberman,<br>Wei Deng, Bo Lu</p>
 </div>
 
 

--- a/public/2023/schedule.html
+++ b/public/2023/schedule.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US"  >
-  <head>
+  <head><!-- m23-gate --><script>(function(){try{if(sessionStorage.getItem('m23_ok')==='1')return;}catch(e){}
+document.documentElement.style.visibility='hidden';
+function show(){
+  document.documentElement.style.visibility='';
+  var d=document.createElement('div');
+  d.id='m23-gate';
+  d.style.cssText='position:fixed;inset:0;z-index:2147483647;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;';
+  d.innerHTML='<form id="m23-form" style="background:#1c1c1c;padding:32px 36px;border-radius:8px;width:340px;max-width:90vw;text-align:center;border:1px solid #333"><h2 style="margin:0 0 8px;font-size:22px;font-weight:600">Manifest 2023</h2><p style="margin:0 0 18px;color:#aaa;font-size:14px">Enter password to view archive</p><input id="m23-pw" type="password" autocomplete="off" autofocus style="width:100%;padding:10px 12px;font-size:16px;background:#111;color:#fff;border:1px solid #444;border-radius:6px;box-sizing:border-box"/><div id="m23-err" style="color:#ff6b6b;font-size:13px;height:18px;margin-top:8px"></div><button type="submit" style="margin-top:10px;width:100%;padding:10px;font-size:15px;background:#fff;color:#111;border:0;border-radius:6px;cursor:pointer;font-weight:600">Enter</button></form>';
+  document.body.appendChild(d);
+  document.getElementById('m23-form').addEventListener('submit',function(e){
+    e.preventDefault();
+    var v=document.getElementById('m23-pw').value;
+    if(v==='2023'){try{sessionStorage.setItem('m23_ok','1');}catch(e){}d.parentNode.removeChild(d);}
+    else{document.getElementById('m23-err').textContent='Incorrect password';}
+  });
+}
+if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
+})();</script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->
@@ -1526,7 +1543,13 @@
 </style><div class="fluid-engine fe-65074783591dcb7344839448"><div class="fe-block fe-block-yui_3_17_2_1_1694975810239_5251"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1694975810239_5251"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <h3 style="white-space:pre-wrap;">Main Events</h3><p class="" style="white-space:pre-wrap;">We’ll have official main events running from 3-11pm Friday, and 10am-11pm Saturday &amp; Sunday.</p><p class="" style="white-space:pre-wrap;"><em>All events and times are tentative, and subject to change</em></p>
+  <h3 style="white-space:pre-wrap;">Main Events</h3><p class="" style="white-space:pre-wrap;">We’ll have official main events running from 3-11pm Friday, and 10am-11pm Saturday &amp; Sunday.</p><p class="" style="white-space:pre-wrap;"><em>All events start 5min after the hour and end 5min before.</em></p>
+</div>
+
+</div></div></div><div class="fe-block"><div class="sqs-block html-block sqs-block-html" data-block-type="2"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h2 style="white-space:pre-wrap;">All Events</h2><p class="" style="white-space:pre-wrap;"><em>All events and times are tentative, and subject to change.</em></p>
 </div>
 
 
@@ -2553,7 +2576,7 @@
 </div></div></div><div class="fe-block fe-block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine</p>
+  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine, Misha Glouberman,<br>Wei Deng, Bo Lu</p>
 </div>
 
 

--- a/public/2023/speakers.html
+++ b/public/2023/speakers.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US"  >
-  <head>
+  <head><!-- m23-gate --><script>(function(){try{if(sessionStorage.getItem('m23_ok')==='1')return;}catch(e){}
+document.documentElement.style.visibility='hidden';
+function show(){
+  document.documentElement.style.visibility='';
+  var d=document.createElement('div');
+  d.id='m23-gate';
+  d.style.cssText='position:fixed;inset:0;z-index:2147483647;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;';
+  d.innerHTML='<form id="m23-form" style="background:#1c1c1c;padding:32px 36px;border-radius:8px;width:340px;max-width:90vw;text-align:center;border:1px solid #333"><h2 style="margin:0 0 8px;font-size:22px;font-weight:600">Manifest 2023</h2><p style="margin:0 0 18px;color:#aaa;font-size:14px">Enter password to view archive</p><input id="m23-pw" type="password" autocomplete="off" autofocus style="width:100%;padding:10px 12px;font-size:16px;background:#111;color:#fff;border:1px solid #444;border-radius:6px;box-sizing:border-box"/><div id="m23-err" style="color:#ff6b6b;font-size:13px;height:18px;margin-top:8px"></div><button type="submit" style="margin-top:10px;width:100%;padding:10px;font-size:15px;background:#fff;color:#111;border:0;border-radius:6px;cursor:pointer;font-weight:600">Enter</button></form>';
+  document.body.appendChild(d);
+  document.getElementById('m23-form').addEventListener('submit',function(e){
+    e.preventDefault();
+    var v=document.getElementById('m23-pw').value;
+    if(v==='2023'){try{sessionStorage.setItem('m23_ok','1');}catch(e){}d.parentNode.removeChild(d);}
+    else{document.getElementById('m23-err').textContent='Incorrect password';}
+  });
+}
+if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
+})();</script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->
@@ -6869,6 +6886,11 @@
   <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-large">Austin Chen</p><p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Cofounder of Manifold</p>
 </div>
 
+</div></div></div><div class="fe-block"><div class="sqs-block html-block sqs-block-html" data-block-type="2"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-large">Saul Munn</p><p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Cofounder of OPTIC</p>
+
 
 
 </div></div></div><div class="fe-block fe-block-1bb429aaa20fbed1b18f"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="102.8663273506563" data-block-type="5" id="block-1bb429aaa20fbed1b18f"><div class="sqs-block-content">
@@ -9383,7 +9405,7 @@
 </div></div></div><div class="fe-block fe-block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine</p>
+  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine, Misha Glouberman,<br>Wei Deng, Bo Lu</p>
 </div>
 
 

--- a/public/2023/tickets.html
+++ b/public/2023/tickets.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US"  >
-  <head>
+  <head><!-- m23-gate --><script>(function(){try{if(sessionStorage.getItem('m23_ok')==='1')return;}catch(e){}
+document.documentElement.style.visibility='hidden';
+function show(){
+  document.documentElement.style.visibility='';
+  var d=document.createElement('div');
+  d.id='m23-gate';
+  d.style.cssText='position:fixed;inset:0;z-index:2147483647;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;';
+  d.innerHTML='<form id="m23-form" style="background:#1c1c1c;padding:32px 36px;border-radius:8px;width:340px;max-width:90vw;text-align:center;border:1px solid #333"><h2 style="margin:0 0 8px;font-size:22px;font-weight:600">Manifest 2023</h2><p style="margin:0 0 18px;color:#aaa;font-size:14px">Enter password to view archive</p><input id="m23-pw" type="password" autocomplete="off" autofocus style="width:100%;padding:10px 12px;font-size:16px;background:#111;color:#fff;border:1px solid #444;border-radius:6px;box-sizing:border-box"/><div id="m23-err" style="color:#ff6b6b;font-size:13px;height:18px;margin-top:8px"></div><button type="submit" style="margin-top:10px;width:100%;padding:10px;font-size:15px;background:#fff;color:#111;border:0;border-radius:6px;cursor:pointer;font-weight:600">Enter</button></form>';
+  document.body.appendChild(d);
+  document.getElementById('m23-form').addEventListener('submit',function(e){
+    e.preventDefault();
+    var v=document.getElementById('m23-pw').value;
+    if(v==='2023'){try{sessionStorage.setItem('m23_ok','1');}catch(e){}d.parentNode.removeChild(d);}
+    else{document.getElementById('m23-err').textContent='Incorrect password';}
+  });
+}
+if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
+})();</script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->
@@ -1287,7 +1304,7 @@
 </style><div class="fluid-engine fe-64985a089665f16bfceb6945"><div class="fe-block fe-block-8ab564e97281bf29b46a"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-8ab564e97281bf29b46a"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <h1 style="white-space:pre-wrap;">Tickets</h1><h4 style="white-space:pre-wrap;">Buy now before they run out — tickets close Tue Sep 19!</h4>
+  <h1 style="white-space:pre-wrap;">Tickets</h1><h4 style="white-space:pre-wrap;">Regular tickets are now closed. If you would like to purchase a supporter ticket, please contact manifest@manifold.markets.</h4>
 </div>
 
 
@@ -1663,7 +1680,7 @@
 </style><div class="fluid-engine fe-64985a089665f16bfceb6948"><div class="fe-block fe-block-9be7d45ec88c1e5f211c"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-9be7d45ec88c1e5f211c"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <h4 style="white-space:pre-wrap;">Main Admission</h4><p class="sqsrte-small" style="white-space:pre-wrap;"><em>M30k / 330 USD</em></p><p class="sqsrte-small" style="white-space:pre-wrap;"><em>50% off for students &amp; employees of forecasting organizations! </em></p><ul data-rte-list="default"><li><p class="sqsrte-small" style="white-space:pre-wrap;">Admission to Manifest 2023 forecasting festival</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">Conference swag</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">Meals throughout the weekend</p></li></ul><p class="sqsrte-small" style="white-space:pre-wrap;">Does not include accommodation.</p>
+  <p class="" style="white-space:pre-wrap;">Manifest starts on Friday, Sept 22, and goes through Sunday, Sept 24.</p>
 </div>
 
 
@@ -1671,7 +1688,7 @@
 </div></div></div><div class="fe-block fe-block-95720b14f6235f1b07cf"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-95720b14f6235f1b07cf"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <h4 style="white-space:pre-wrap;">Supporter</h4><p class="sqsrte-small" style="white-space:pre-wrap;"><em>M200k / 2.2k USD</em></p><ul data-rte-list="default"><li><p class="sqsrte-small" style="white-space:pre-wrap;">Admission to Manifest 2023 forecasting festival</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">Conference swag</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">Meals throughout the weekend</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">Dinner with the Manifest guests of honor, speakers, and the Manifold team</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">(Optionally) your own name everywhere we list sponsors</p></li><li><p class="sqsrte-small" style="white-space:pre-wrap;">Fame, glory, our eternal thanks, etc.</p></li></ul><p class="sqsrte-small" style="white-space:pre-wrap;">Does not include accommodation.</p>
+  <p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p>
 </div>
 
 
@@ -2901,7 +2918,7 @@
 </div></div></div><div class="fe-block fe-block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1694002771445_2879"><div class="sqs-block-content">
 
 <div class="sqs-html-content">
-  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine</p>
+  <p style="text-align:center;white-space:pre-wrap;" class="sqsrte-small">Supported by: Jonathan Ray, Liron Shapira, Michael Tebbs, Andreas Finke, Vasily Artyukhov, David Hsu, Dean Valentine, Misha Glouberman,<br>Wei Deng, Bo Lu</p>
 </div>
 
 


### PR DESCRIPTION
## Summary
- Match visible content on /2023 to the 2023-10-01 Wayback snapshot (Lighthaven rename, supporters list, schedule + speakers + tickets updates)
- Add the same sessionStorage password gate that /2024 uses (password: 2023)

## Test plan
- [ ] /2023 prompts for password; entering "2023" reveals the page
- [ ] Spot-check /2023, /2023/schedule, /2023/speakers, /2023/tickets, /2023/contact against the 2023-10-01 Wayback snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)