### PR TITLE
Add Google Fonts fallback for dead Typekit URL on /2023

### DIFF
--- a/public/2023/contact.html
+++ b/public/2023/contact.html
@@ -18,6 +18,20 @@ function show(){
 }
 if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
 })();</script>
+<!-- m23-font-fix -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Karla:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+body, p, li, span, a, blockquote, button, input, textarea, select,
+.sqsrte-large, .sqsrte-small, .sqs-html-content {
+  font-family: 'Karla', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+h1, h2, h3, h4, h5, h6, .header-display-desktop, .header-display-mobile,
+.header-nav, .header-actions, .header-menu-nav-item {
+  font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+</style>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->

--- a/public/2023/index.html
+++ b/public/2023/index.html
@@ -18,6 +18,20 @@ function show(){
 }
 if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
 })();</script>
+<!-- m23-font-fix -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Karla:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+body, p, li, span, a, blockquote, button, input, textarea, select,
+.sqsrte-large, .sqsrte-small, .sqs-html-content {
+  font-family: 'Karla', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+h1, h2, h3, h4, h5, h6, .header-display-desktop, .header-display-mobile,
+.header-nav, .header-actions, .header-menu-nav-item {
+  font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+</style>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->

--- a/public/2023/schedule.html
+++ b/public/2023/schedule.html
@@ -18,6 +18,20 @@ function show(){
 }
 if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
 })();</script>
+<!-- m23-font-fix -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Karla:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+body, p, li, span, a, blockquote, button, input, textarea, select,
+.sqsrte-large, .sqsrte-small, .sqs-html-content {
+  font-family: 'Karla', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+h1, h2, h3, h4, h5, h6, .header-display-desktop, .header-display-mobile,
+.header-nav, .header-actions, .header-menu-nav-item {
+  font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+</style>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->

--- a/public/2023/speakers.html
+++ b/public/2023/speakers.html
@@ -18,6 +18,20 @@ function show(){
 }
 if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
 })();</script>
+<!-- m23-font-fix -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Karla:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+body, p, li, span, a, blockquote, button, input, textarea, select,
+.sqsrte-large, .sqsrte-small, .sqs-html-content {
+  font-family: 'Karla', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+h1, h2, h3, h4, h5, h6, .header-display-desktop, .header-display-mobile,
+.header-nav, .header-actions, .header-menu-nav-item {
+  font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+</style>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->

--- a/public/2023/tickets.html
+++ b/public/2023/tickets.html
@@ -18,6 +18,20 @@ function show(){
 }
 if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',show);}else{show();}
 })();</script>
+<!-- m23-font-fix -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Karla:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+body, p, li, span, a, blockquote, button, input, textarea, select,
+.sqsrte-large, .sqsrte-small, .sqs-html-content {
+  font-family: 'Karla', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+h1, h2, h3, h4, h5, h6, .header-display-desktop, .header-display-mobile,
+.header-nav, .header-actions, .header-menu-nav-item {
+  font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;
+}
+</style>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- This is Squarespace. --><!-- ellipse-heptagon-smgm -->


### PR DESCRIPTION
## Summary
- The original Typekit URL is a dead session token; without it, /2023 text falls back to system fonts and reads inconsistently
- Inject Karla + DM Sans from Google Fonts and override body/heading font-family declarations so the pages render with consistent type

## Test plan
- [ ] /2023 text on body / cards / headings uses Karla / DM Sans (no longer system-default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)