### PR TITLE
Past sessions: title font, default sort, description tweaks

### DIFF
--- a/public/pastsessions/events-2025.json
+++ b/public/pastsessions/events-2025.json
@@ -262,7 +262,7 @@
         "venue": "Exobrain",
         "start": "10:00 PM",
         "end": "11:00 PM",
-        "description": "I have received many requests to run a drama/improv workshop again this year. For reference, I am a professional at this, it is my main job in Australia (which is why the games are from Australia) Games are currently TBD. WE WILL NOT BE PLAYING Ŗ̶̙̟̲͎̦̻̙̬̫̤͔̝̍͗̒̓̈́͆E̴̯̒͌́D̵̫͍̥̝͙͂̃̆̀͝Ą̷̥̙͓̞̲̪̦͉̦̖͔̮̤͐C̷̘̙̼̰̭͎͍̳̫̖͈͓̭͖̝̓̋͂T̶̨̻̦̠͙͔͕͕̤̈́̽̄̈́̃͗͘E̵̮͚̳̟͙͑̈̂̔̿̈́̓̋̍̾̈̊̾̍͝ͅD̸̢̛͓̠̼͕̫̤̈̔͂̾̅̌̕͜͠"
+        "description": "I have received many requests to run a drama/improv workshop again this year. For reference, I am a professional at this, it is my main job in Australia (which is why the games are from Australia) Games are currently TBD."
       }
     ]
   },
@@ -1075,7 +1075,7 @@
         "venue": "",
         "start": "10:00 PM",
         "end": "",
-        "description": "I have received many requests to run a drama/improv workshop again this year. For reference, I am a professional at this, it is my main job in Australia (which is why the games are from Australia) Games are currently TBD. WE WILL NOT BE PLAYING Ŗ̶̙̟̲͎̦̻̙̬̫̤͔̝̍͗̒̓̈́͆E̴̯̒͌́D̵̫͍̥̝͙͂̃̆̀͝Ą̷̥̙͓̞̲̪̦͉̦̖͔̮̤͐C̷̘̙̼̰̭͎͍̳̫̖͈͓̭͖̝̓̋͂T̶̨̻̦̠͙͔͕͕̤̈́̽̄̈́̃͗͘E̵̮͚̳̟͙͑̈̂̔̿̈́̓̋̍̾̈̊̾̍͝ͅD̸̢̛͓̠̼͕̫̤̈̔͂̾̅̌̕͜͠"
+        "description": "I have received many requests to run a drama/improv workshop again this year. For reference, I am a professional at this, it is my main job in Australia (which is why the games are from Australia) Games are currently TBD."
       }
     ]
   },

--- a/public/pastsessions/index.html
+++ b/public/pastsessions/index.html
@@ -60,7 +60,7 @@
     flex-wrap: wrap;
   }
   header.site h1 {
-    font-family: var(--font-cinzel-deco);
+    font-family: var(--font-libre-baskerville);
     font-size: 34px;
     font-weight: 700;
     margin: 0;
@@ -224,6 +224,7 @@
   }
   #session-tooltip .tooltip-description {
     white-space: pre-wrap;
+    line-height: 1.65;
   }
   .session .cat-label {
     font-family: var(--font-cinzel);
@@ -350,8 +351,8 @@
     </select>
     <label for="sort-by">Sort by</label>
     <select id="sort-by">
-      <option value="default">Session type</option>
       <option value="rsvp">Attendee count</option>
+      <option value="default">Session type</option>
       <option value="time">Time</option>
     </select>
   </div>


### PR DESCRIPTION
Changes to the past sessions page:

- Switch the **Schedule of Previous Years** title font to Libre Baskerville
- Default the **Sort by** dropdown to *Attendee count* (was *Session type*)
- Loosen tooltip description line-height to 1.65 for easier reading
- Strip the zalgo-corrupted `REDACTED` text (and `WE WILL NOT BE PLAYING` line) from the *Rare & Exotic-ish Drama Games from Australia* descriptions in `events-2025.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)