### PR TITLE
2026 homepage: past sessions link, sponsors heading, copy trims

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -870,7 +870,7 @@ const PAGE_HTML = `
 <!-- SPONSORS (original layout) -->
 <section id="sponsors" class="sponsors-orig scroll-mt">
   <hr class="v1-divider" />
-  <h2 class="v1-h2 v1-h2--center" style="font-family: var(--deco); font-style: normal; font-weight: 400; font-size: 48px; letter-spacing: 0.04em;">Sponsors of 2025</h2>
+  <h2 class="v1-h2 v1-h2--center" style="font-family: var(--deco); font-style: normal; font-weight: 400; font-size: 48px; letter-spacing: 0.04em;">Past Sponsors</h2>
   <div class="sponsors-stack">
     <a href="https://polymarket.com" target="_blank" rel="noopener"><div class="mono-img mono-img--polymarket" role="img" aria-label="Polymarket"></div></a>
     <div class="sponsors-row">
@@ -983,7 +983,6 @@ const PAST_GUESTS: [string, string][] = [
   ['Noam Brown', 'OpenAI'],
   ['Oliver Habryka', 'Lightcone'],
   ['Panda Smith', 'Researcher'],
-  ['Ric Best', 'Substack'],
   ['Rob Miles', 'AI Safety'],
   ['Samo Burja', 'Bismarck Analysis'],
   ['Samuel Hammond', 'FAI'],

--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -289,6 +289,24 @@ nav.top.is-scrolled .top__register { color: #fff !important; }
   flex: 1; font-family: var(--serif); font-style: normal; font-weight: 400;
   font-size: 14px; color: var(--pdeep); letter-spacing: 0;
 }
+.v1-themes__more {
+  display: flex; justify-content: center; padding: 36px 56px;
+  border-bottom: 1px solid var(--rule);
+}
+.v1-themes__more-link {
+  font-family: var(--cinzel); font-weight: 700; font-size: 13px;
+  letter-spacing: 0.18em; text-transform: uppercase; text-decoration: none;
+  color: var(--pdeep); padding-bottom: 4px;
+  border-bottom: 1px dotted rgba(74,58,107,0.45);
+  transition: color 160ms, border-color 160ms, transform 160ms;
+}
+.v1-themes__more-link:hover {
+  color: var(--m26-btn); border-color: var(--m26-btn);
+}
+.v1-themes__more-link .v1-themes__more-arrow {
+  display: inline-block; margin-left: 10px; transition: transform 200ms;
+}
+.v1-themes__more-link:hover .v1-themes__more-arrow { transform: translateX(4px); }
 
 /* ----- NIGHT MARKET (V1) ----- */
 .v1-nm { padding: 0 56px 88px; }
@@ -605,6 +623,8 @@ nav.top.is-scrolled .top__register { color: #fff !important; }
   .v1-what__text { padding: 0 24px; }
   .v1-cell { padding: 28px 24px; }
   .v1-cell--list header { margin: 0 -24px 18px; padding: 22px 24px 14px; }
+  .v1-themes__more { padding: 28px 24px; }
+  .v1-themes__more-link { font-size: 11px; letter-spacing: 0.16em; text-align: center; }
   .v1-foot { padding: 40px 24px 48px; }
   .v1-foot__row { flex-direction: column; gap: 24px; }
   .v1-foot__links { justify-content: flex-start; }
@@ -683,7 +703,7 @@ const PAGE_HTML = `
       <p class="v1-lede">Manifest started in <a href="/2023">2023</a> as a festival about prediction markets and forecasting; it has since become an annual excuse to treat curiosity as a serious hobby — long conversations, unfinished arguments, bets, and the company of writers, researchers, and builders you admire from your favorite niche corners of the internet.</p>
       <p class="v1-body">&ldquo;Equal parts Math Olympiad and Burning Man&rdquo; — a gathering of nerds who want to find the thinkers and practitioners they vehemently agree (and disagree) with, share a meal around a cozy campfire, and come away with radically new ways of thinking.</p>
       <h3 class="v1-themes__title">What sorts of things happen at Manifest?</h3>
-      <p class="v1-themes__sub">Talks, panels, debates, workshops, games, prediction market tournaments, a night market, career fair, and much more.<br/><br/>Much of the schedule comes from attendee-led sessions. Past years have included&thinsp;—</p>
+      <p class="v1-themes__sub">Talks, panels, debates, workshops, games, prediction market tournaments, a night market, career fair, and much more. Much of the schedule comes from attendee-led sessions.</p>
     </div>
     <div class="v1-what__images">
       <div class="v1-what__img-wrap"><img class="v1-what__img" src="/images/2026/what-is-manifest-1.jpg" alt="Attendees gathered under sunshade canopies at Manifest" loading="lazy" decoding="async" /></div>
@@ -760,6 +780,9 @@ const PAGE_HTML = `
     <figure class="v1-cell v1-cell--photo">
       <div class="v1-cell__img" style="background-image:url('/images/themes/much-more-guitar.png')"></div>
     </figure>
+  </div>
+  <div class="v1-themes__more">
+    <a class="v1-btn v1-btn--ink pill v1-themes__more-btn" href="/pastsessions">See sessions from all previous years<span class="v1-themes__more-arrow">→</span></a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Combine "What sorts of things happen at Manifest?" into two clean sentences (drop "Past years have included —" trailing fragment).
- Add a centered "Click here to see the sessions from all previous years →" link row at the bottom of the themes grid, linking to `/pastsessions` (already rewritten in `next.config.js`).
- Sponsors section heading: "Sponsors of 2025" → "Past Sponsors".
- Drop the `['Ric Best', 'Substack']` entry from `PAST_GUESTS` — typo for Chris Best, who is already featured (L675) and in the Past Fireside list (L762).

## Test plan
- [ ] `bun run dev` → http://localhost:3000
- [ ] Scroll to "What sorts of things happen at Manifest?" — copy reads as two sentences, no orphan dash.
- [ ] Below the Talks/Workshops/Fireside/& Much more grid, the "see past sessions" link is visible, centered, and routes to `/pastsessions`.
- [ ] Sponsors section title reads "Past Sponsors".
- [ ] Speakers "And many more" grid no longer contains "Ric Best, Substack".
- [ ] Vercel preview deploy looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)