### PR TITLE
Fix Night Market register-interest link

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -1238,7 +1238,7 @@ function NightMarket() {
       </div>
       <div className="v1-nm__cta">
         <a
-          href="https://airtable.com/appMZp1aBO5b7NTdM/pag9gppXcX1cxRixI/edit"
+          href="https://airtable.com/appMZp1aBO5b7NTdM/pag9gppXcX1cxRixI/form"
           className="v1-btn v1-btn--ink pill"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
## Summary
- Updates the Night Market "Register your interest" link from `/edit` to `/form` on the Airtable URL so it opens the public form.

## Test plan
- [ ] Click "Register your interest" in the Night Market section on /2026 and confirm it opens the Airtable form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)