### PR TITLE
Remove a16z from David Oks's role

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -18,7 +18,7 @@ const confirmedSpeakers: Person[] = [
   { name: 'Patrick McKenzie', role: 'patio11', image: '/images/speakers/patrick.jpg' },
   { name: 'Scott Alexander', role: 'Astral Codex Ten', image: '/images/speakers/scott.jpg' },
   { name: 'Chris Best', role: 'CEO, Substack', image: '/images/speakers/chris.jpg' },
-  { name: 'David Oks', role: 'Writer, a16z', image: '/images/2026/guests/david-oks.png' },
+  { name: 'David Oks', role: 'Writer', image: '/images/2026/guests/david-oks.png' },
   // { name: 'Tracing Woodgrains', role: '@TracingWoodgrains, Writer', image: '/images/2026/guests/tracing-woodgrains.jpg' },
   { name: 'Jasmine Sun', role: 'Writer', image: '/images/2026/guests/jasmine-sun.jpg' },
   { name: 'Robin Hanson', role: 'George Mason University', image: '/images/speakers/robin.jpg' },

--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -1238,7 +1238,7 @@ function NightMarket() {
       </div>
       <div className="v1-nm__cta">
         <a
-          href="https://airtable.com/appMZp1aBO5b7NTdM/pag9gppXcX1cxRixI/edit"
+          href="https://airtable.com/appMZp1aBO5b7NTdM/pag9gppXcX1cxRixI/form"
           className="v1-btn v1-btn--ink pill"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
Updates David Oks's role label from 'Writer, a16z' to 'Writer' on the 2026 speakers list.