### PR TITLE
Add lead-in for past session examples

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -1146,8 +1146,9 @@ function WhatIsManifest() {
           </p>
           <h3 className="v1-themes__title">What sorts of things happen at Manifest?</h3>
           <p className="v1-themes__sub">
-            Talks, panels, debates, workshops, games, prediction market tournaments, a night market,
-            career fair, and much more. Much of the schedule comes from attendee-led sessions.
+            Talks, panels, debates, workshops, games, prediction market tournaments, a night
+            market, career fair, and much more. Much of the schedule comes from attendee-led
+            sessions. Sessions from past years included:
           </p>
         </div>
         <div className="v1-what__images">


### PR DESCRIPTION
## Summary
- Adds "Sessions from past years included:" to the end of the "What sorts of things happen at Manifest?" paragraph in `app/2026/Manifest2026.tsx`, setting up a list of past-session examples to follow.

## Test plan
- [ ] Verify copy renders correctly on the 2026 page at the "What is Manifest?" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)