### PR TITLE
Update Sreeram Kannan affiliation to Eigen Labs

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -45,7 +45,7 @@ const ticketholders: Ticketholder[] = [
   // { answerId: 'tdz5lShpN8', name: 'Robert Miles', role: '@RobertMilesAI', image: '/images/2026/guests/rob-miles.jpg' },
   { answerId: '8298A2UEOu', name: 'Kelsey Piper', role: 'The Argument', image: '/images/2026/guests/kelsey-piper.jpeg' },
   { answerId: 'RpOtQuq9C2', name: 'David Shor', role: 'Blue Rose Research', image: '/images/speakers/davidshor.jpg' },
-  { answerId: 'IPuznZ0ICt', name: 'Sreeram Kannan', role: 'EigenLayer', image: '/images/2026/guests/sreeram-kannan.png' },
+  { answerId: 'IPuznZ0ICt', name: 'Sreeram Kannan', role: 'Eigen Labs', image: '/images/2026/guests/sreeram-kannan.png' },
   { answerId: '2ZqtuNtuN2', name: 'Andreas Stuhlmüller', role: 'Elicit', image: '/images/2026/guests/andreas-stuhlmueller.png' },
 ]
 


### PR DESCRIPTION
## Summary
- Change Sreeram Kannan's listed affiliation from EigenLayer to Eigen Labs on the 2026 page.

## Test plan
- [ ] Verify speaker card shows "Eigen Labs" on the 2026 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)