### PR TITLE
Move Sreeram Kannan to confirmed speakers

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -31,6 +31,7 @@ const confirmedSpeakers: Person[] = [
   // { name: 'Aydin Mohseni', role: 'Philosopher of science and Bayesian epistemologist, CMU', image: '/images/2026/guests/aydin-mohseni.jpg' },
   { name: 'Scott Sumner', role: 'Economist', image: '/images/2026/guests/scott-sumner.jpg' },
   { name: 'Destiny', role: 'Streamer', image: '/images/2026/guests/destiny.jpg' },
+  { name: 'Sreeram Kannan', role: 'Eigen Labs', image: '/images/2026/guests/sreeram-kannan.png' },
 ]
 
 const ticketholders: Ticketholder[] = [
@@ -45,7 +46,6 @@ const ticketholders: Ticketholder[] = [
   // { answerId: 'tdz5lShpN8', name: 'Robert Miles', role: '@RobertMilesAI', image: '/images/2026/guests/rob-miles.jpg' },
   { answerId: '8298A2UEOu', name: 'Kelsey Piper', role: 'The Argument', image: '/images/2026/guests/kelsey-piper.jpeg' },
   { answerId: 'RpOtQuq9C2', name: 'David Shor', role: 'Blue Rose Research', image: '/images/speakers/davidshor.jpg' },
-  { answerId: 'IPuznZ0ICt', name: 'Sreeram Kannan', role: 'Eigen Labs', image: '/images/2026/guests/sreeram-kannan.png' },
   { answerId: '2ZqtuNtuN2', name: 'Andreas Stuhlmüller', role: 'Elicit', image: '/images/2026/guests/andreas-stuhlmueller.png' },
 ]
 


### PR DESCRIPTION
## Summary
- Move Sreeram Kannan from probabilistic ticketholders to confirmed speakers on the 2026 page.

## Test plan
- [ ] Verify Sreeram shows in the confirmed speakers section on /2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)