### PR TITLE
Redirect /volunteer-guide to 2026 Volunteer Guide

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,16 @@ const nextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: '/volunteer-guide',
+        destination:
+          'https://www.notion.so/manifoldmarkets/2026-Volunteer-Guide-Manifest-c6e54492ea7a83baa9e881d6b7356ad0?source=copy_link',
+        permanent: false,
+      },
+    ]
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
Adds a redirect so `manifest.is/volunteer-guide` points to the 2026 Volunteer Guide on Notion.

Uses a temporary (307) redirect since the Notion link will likely change after the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)