### PR TITLE
Redirect /map to 2026 event map

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,11 @@ const nextConfig = {
           'https://www.notion.so/manifoldmarkets/2026-Volunteer-Guide-Manifest-c6e54492ea7a83baa9e881d6b7356ad0?source=copy_link',
         permanent: false,
       },
+      {
+        source: '/map',
+        destination: 'https://waypoint.lighthaven.space/e/manifest-2026/map',
+        permanent: false,
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
Adds a redirect so `manifest.is/map` points to the Manifest 2026 event map on Waypoint.

Temporary (307) redirect, consistent with `/volunteer-guide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)