### PR TITLE
Redirect /emptybadge to badge request Airtable form

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,12 @@ const nextConfig = {
         destination: 'https://waypoint.lighthaven.space/e/manifest-2026/map',
         permanent: false,
       },
+      {
+        source: '/emptybadge',
+        destination:
+          'https://airtable.com/appMZp1aBO5b7NTdM/pag0LLgblrhQ8TjdK/form',
+        permanent: false,
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
Adds a redirect from `manifest.is/emptybadge` to the badge request Airtable form, following the same pattern as `/map` and `/volunteer-guide`.

- Source: `/emptybadge`
- Destination: `https://airtable.com/appMZp1aBO5b7NTdM/pag0LLgblrhQ8TjdK/form`
- `permanent: false` (302), so the link can be repointed later

🤖 Generated with [Claude Code](https://claude.com/claude-code)