### PR TITLE
Remove /emptybadge redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,12 +22,6 @@ const nextConfig = {
         destination: 'https://waypoint.lighthaven.space/e/manifest-2026/map',
         permanent: false,
       },
-      {
-        source: '/emptybadge',
-        destination:
-          'https://airtable.com/appMZp1aBO5b7NTdM/pag0LLgblrhQ8TjdK/form',
-        permanent: false,
-      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
Removes the `/emptybadge` redirect added in #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)