### PR TITLE
Redirect /schedule to 2026 event schedule

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,12 @@ const nextConfig = {
         destination: 'https://waypoint.lighthaven.space/e/manifest-2026/map',
         permanent: false,
       },
+      {
+        source: '/schedule',
+        destination:
+          'https://waypoint.lighthaven.space/e/manifest-2026/schedule',
+        permanent: false,
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
Adds a redirect from `manifest.is/schedule` to the Waypoint 2026 event schedule, following the same pattern as `/map`.

- Source: `/schedule`
- Destination: `https://waypoint.lighthaven.space/e/manifest-2026/schedule`
- `permanent: false` (302), so the link can be repointed later

🤖 Generated with [Claude Code](https://claude.com/claude-code)