### PR TITLE
Redirect /ticket to 2026 admission QR

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,12 @@ const nextConfig = {
           'https://waypoint.lighthaven.space/e/manifest-2026/schedule',
         permanent: false,
       },
+      {
+        source: '/ticket',
+        destination:
+          'https://waypoint.lighthaven.space/e/manifest-2026/admission-qr',
+        permanent: false,
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
Adds a redirect from `manifest.is/ticket` to the Waypoint 2026 admission QR, following the same pattern as `/map` and `/schedule`.

- Source: `/ticket`
- Destination: `https://waypoint.lighthaven.space/e/manifest-2026/admission-qr`
- `permanent: false` (302), so the link can be repointed later

🤖 Generated with [Claude Code](https://claude.com/claude-code)