### PR TITLE
Redirect /volunteer-guide-registration to Registration Volunteer Guide

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,12 @@ const nextConfig = {
           'https://waypoint.lighthaven.space/e/manifest-2026/admission-qr',
         permanent: false,
       },
+      {
+        source: '/volunteer-guide-room',
+        destination:
+          'https://www.notion.so/manifoldmarkets/Registration-Volunteer-Guide-06954492ea7a838496568163bd3b9e8e?source=copy_link',
+        permanent: false,
+      },
     ]
   },
   async rewrites() {

--- a/next.config.js
+++ b/next.config.js
@@ -35,7 +35,7 @@ const nextConfig = {
         permanent: false,
       },
       {
-        source: '/volunteer-guide-room',
+        source: '/volunteer-guide-registration',
         destination:
           'https://www.notion.so/manifoldmarkets/Registration-Volunteer-Guide-06954492ea7a838496568163bd3b9e8e?source=copy_link',
         permanent: false,


### PR DESCRIPTION
Adds a `/volunteer-guide-registration` redirect (temporary) to the Registration Volunteer Guide Notion page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)