### PR TITLE
Remove public 2026 working schedule link from landing page

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -524,7 +524,6 @@ nav.top.is-scrolled .top__register { color: #fff !important; }
   transition: color 180ms ease;
 }
 .v1-spk-more__grid a:hover { color: var(--plav); }
-.v1-speakers__schedule { display: flex; justify-content: center; margin-top: 48px; }
 
 /* ----- WHAT IS MANIFEST (V1) ----- */
 .v1-what { margin: 0; padding: 0; }
@@ -1170,16 +1169,6 @@ function Speakers({ probabilities }: { probabilities: Record<string, number> }) 
         </div>
       </div>
 
-      <div className="v1-speakers__schedule">
-        <a
-          className="v1-btn v1-btn--ink pill"
-          href="https://waypoint.lighthaven.space/e/manifest-2026/schedule"
-          target="_blank"
-          rel="noopener"
-        >
-          2026 working schedule
-        </a>
-      </div>
     </section>
   )
 }


### PR DESCRIPTION
Removes the "2026 working schedule" button (and its now-unused CSS rule) from the 2026 landing page so the working schedule is no longer linked publicly from manifest.is.

Note: the schedule itself is hosted on Waypoint (`waypoint.lighthaven.space`) and is outside this repo. Other references to it still exist — the `/schedule` redirect in `next.config.js` and the Schedule section in the attendee guide. Let me know if those should go too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)