### PR TITLE
Move FutureSearch logo to bottom sponsor row after Eigen Labs

### DIFF
--- a/app/2026/Manifest2026.tsx
+++ b/app/2026/Manifest2026.tsx
@@ -816,7 +816,7 @@ nav.top.is-scrolled .top__register { color: #fff !important; }
 .sponsors-tier--md .sponsors-logo--sportspredict { max-height: 50px; max-width: 138px; transform: translateY(6px); }
 .sponsors-tier--md .sponsors-logo--mnx { max-height: 50px; max-width: 138px; }
 .sponsors-tier--md .sponsors-logo--futo { max-height: 50px; max-width: 138px; }
-.sponsors-tier--md .sponsors-logo--futuresearch { max-height: 38px; max-width: 220px; }
+.sponsors-tier--sm .sponsors-logo--futuresearch { max-height: 30px; max-width: 200px; }
 .sponsors-cta { margin-top: 40px; text-align: center; }
 .btn-solid {
   display: inline-block;
@@ -1411,15 +1411,6 @@ function Sponsors() {
               className="sponsors-logo sponsors-logo--sportspredict"
             />
           </a>
-          <a href="https://futuresearch.ai/" target="_blank" rel="noopener">
-            <Image
-              src="/images/sponsors/futuresearch-logo.png"
-              alt="FutureSearch"
-              width={1144}
-              height={168}
-              className="sponsors-logo sponsors-logo--futuresearch"
-            />
-          </a>
         </div>
         <div className="sponsors-tier sponsors-tier--sm sponsors-row">
           <Image
@@ -1436,6 +1427,15 @@ function Sponsors() {
             height={200}
             className="sponsors-logo sponsors-logo--eigen"
           />
+          <a href="https://futuresearch.ai/" target="_blank" rel="noopener">
+            <Image
+              src="/images/sponsors/futuresearch-logo.png"
+              alt="FutureSearch"
+              width={1144}
+              height={168}
+              className="sponsors-logo sponsors-logo--futuresearch"
+            />
+          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Moves the FutureSearch logo from the medium-tier row (after Sports Predict) to the bottom small-tier row, after Eigen Labs. Sizing adjusted to match the sm tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)