### PR TITLE
Redirect /feedback to Airtable feedback form

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,12 @@ const nextConfig = {
           'https://waypoint.lighthaven.space/e/manifest-2026/admission-qr',
         permanent: false,
       },
+      {
+        source: '/feedback',
+        destination:
+          'https://airtable.com/app3T5RL0xfEKlRIc/pagDs8E00yNO0eD92/form',
+        permanent: false,
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
Adds a `/feedback` redirect pointing `manifest.is/feedback` to the Airtable feedback form, following the same pattern as `/ticket` and `/schedule`.

- `manifest.is/feedback` → `https://airtable.com/app3T5RL0xfEKlRIc/pagDs8E00yNO0eD92/form`
- Temporary redirect (`permanent: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)